### PR TITLE
Add a package.json, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "clarifai",
+  "version": "1.0.0",
+  "description": "Clarifai API Node.js Client",
+  "main": "clarifai_node.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Clarifai/clarifai-nodejs.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Clarifai/clarifai-nodejs/issues"
+  },
+  "homepage": "https://github.com/Clarifai/clarifai-nodejs#readme",
+  "devDependencies": {
+    "stdio": "^0.2.7"
+  },
+  "dependencies": {
+    "querystring": "^0.2.0"
+  }
+}


### PR DESCRIPTION
hey @jimreesman!

this basically fixes #2. i've listed the license as `MIT`. maybe you want [something different](http://choosealicense.com/).

the license, along with explicitly listing dependencies, will make this easier to use. people can interact with the repo by just cloning the repo, running `npm install`, adding their API keys, and running `node clarifai_sample.js`.

also, if you're all set up on `npm`, _you_ should be able to run `npm publish`, which will publish the package `clarifai` at version `1.0.0`, as listed in the `package.json`. [this link](https://docs.npmjs.com/getting-started/publishing-npm-packages) might explain things better.

i hope this helps! :star2: 