### PR TITLE
fix: package compatibility with ESM and CJS environments

### DIFF
--- a/docs/classes/App.md
+++ b/docs/classes/App.md
@@ -177,7 +177,7 @@ import {
   ModelVersion,
   OutputInfo,
 } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { Struct } from "google-protobuf/google/protobuf/struct_pb";
+import { Struct } from "google-protobuf/google/protobuf/struct_pb.js";
 
 const app = new App({
   authConfig: {

--- a/docs/classes/Model.md
+++ b/docs/classes/Model.md
@@ -145,7 +145,7 @@ import {
   ModelVersion,
   OutputInfo,
 } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { Struct } from "google-protobuf/google/protobuf/struct_pb";
+import { Struct } from "google-protobuf/google/protobuf/struct_pb.js";
 
 export const model = new Model({
   modelId: "margin-100-image-cropper",

--- a/examples/app/createModel.ts
+++ b/examples/app/createModel.ts
@@ -3,7 +3,7 @@ import {
   ModelVersion,
   OutputInfo,
 } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { Struct } from "google-protobuf/google/protobuf/struct_pb";
+import { Struct } from "google-protobuf/google/protobuf/struct_pb.js";
 
 const app = new App({
   authConfig: {

--- a/examples/model/createVersion.ts
+++ b/examples/model/createVersion.ts
@@ -3,7 +3,7 @@ import {
   ModelVersion,
   OutputInfo,
 } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { Struct } from "google-protobuf/google/protobuf/struct_pb";
+import { Struct } from "google-protobuf/google/protobuf/struct_pb.js";
 
 export const model = new Model({
   modelId: "margin-100-image-cropper",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "async": "^3.2.5",
         "axios": "^1.8.2",
         "chalk": "^5.3.0",
-        "clarifai-nodejs-grpc": "^11.3.4",
+        "clarifai-nodejs-grpc": "^11.4.2",
         "csv-parse": "^5.5.5",
         "from-protobuf-object": "^1.0.3",
         "google-protobuf": "^3.21.2",
@@ -28,8 +28,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@parcel/packager-ts": "^2.11.0",
-        "@parcel/transformer-typescript-types": "^2.11.0",
+        "@parcel/packager-ts": "^2.15.2",
+        "@parcel/transformer-typescript-types": "^2.15.2",
         "@types/async": "^3.2.24",
         "@types/google-protobuf": "^3.15.12",
         "@types/js-yaml": "^4.0.9",
@@ -44,7 +44,7 @@
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "parcel": "^2.11.0",
+        "parcel": "^2.15.2",
         "prettier": "3.2.4",
         "typedoc": "^0.25.12",
         "typedoc-plugin-include-example": "^1.2.0",
@@ -1017,90 +1017,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
@@ -1117,91 +1033,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
@@ -1718,33 +1549,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2283,59 +2087,37 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.11.0.tgz",
-      "integrity": "sha512-ZIs0865Lp871ZK83k5I9L4DeeE26muNMrHa7j8bvls6fKBJKAn8djrhfU4XOLyziU4aAOobcPwXU0+npWqs52g==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.15.2.tgz",
+      "integrity": "sha512-k0psV7OZYs1g6jcJweBjINVZaVTcfFr6PuCQr28biZ85qbc70f5pWzCzY963+dF3XO/QwTzDABZsJUiDf5jPfQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/graph": "3.5.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/cache": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.11.0.tgz",
-      "integrity": "sha512-RSSkGNjO00lJPyftzaC9eaNVs4jMjPSAm0VJNWQ9JSm2n4A9BzQtTFAt1vhJOzzW1UsQvvBge9DdfkB7a2gIOw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "lmdb": "2.8.5"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.11.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.11.0.tgz",
-      "integrity": "sha512-YHs9g/i5af/sd/JrWAojU9YFbKffcJ3Tx2EJaK0ME8OJsye91UaI/3lxSUYLmJG9e4WLNJtqci8V5FBMz//ZPg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.15.2.tgz",
+      "integrity": "sha512-uzcHUXBXV+vUqXE7SR6Et60GauPGTWvc381pVzCzc90VQJyWY/xyRRIgcA+4MLi2+lQj+w4Uq9H9qg+hMx/JFg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0"
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2359,16 +2141,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.11.0.tgz",
-      "integrity": "sha512-RArhBPRTCfz77soX2IECH09NUd76UBWujXiPRcXGPIHK+C3L1cRuzsNcA39QeSb3thz3b99JcozMJ1nkC2Bsgw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.15.2.tgz",
+      "integrity": "sha512-p+Rr70kX6+bcFPtrrKFdNYnZzdSRSWXi8fvLzZtxissX2ANYS1oFdF6ia37pnzVlHhuYcN6HHMIHbDzJmRvMqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -2376,111 +2158,211 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.11.0.tgz",
-      "integrity": "sha512-1e2+qcZkm5/0f4eI20p/DemcYiSxq9d/eyjpTXA7PulJaHbL1wonwUAuy3mvnAvDnLOJmAk/obDVgX1ZfxMGtg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.15.2.tgz",
+      "integrity": "sha512-spJWqNnymehtESYM89d/E7P7WgFJ7PpOwr2Y1k1ItdEzuq87FZvudAs8bccXMHD69IgtEes+B0dUSEiOb8YlMQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.11.0",
-        "@parcel/compressor-raw": "2.11.0",
-        "@parcel/namer-default": "2.11.0",
-        "@parcel/optimizer-css": "2.11.0",
-        "@parcel/optimizer-htmlnano": "2.11.0",
-        "@parcel/optimizer-image": "2.11.0",
-        "@parcel/optimizer-svgo": "2.11.0",
-        "@parcel/optimizer-swc": "2.11.0",
-        "@parcel/packager-css": "2.11.0",
-        "@parcel/packager-html": "2.11.0",
-        "@parcel/packager-js": "2.11.0",
-        "@parcel/packager-raw": "2.11.0",
-        "@parcel/packager-svg": "2.11.0",
-        "@parcel/packager-wasm": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/resolver-default": "2.11.0",
-        "@parcel/runtime-browser-hmr": "2.11.0",
-        "@parcel/runtime-js": "2.11.0",
-        "@parcel/runtime-react-refresh": "2.11.0",
-        "@parcel/runtime-service-worker": "2.11.0",
-        "@parcel/transformer-babel": "2.11.0",
-        "@parcel/transformer-css": "2.11.0",
-        "@parcel/transformer-html": "2.11.0",
-        "@parcel/transformer-image": "2.11.0",
-        "@parcel/transformer-js": "2.11.0",
-        "@parcel/transformer-json": "2.11.0",
-        "@parcel/transformer-postcss": "2.11.0",
-        "@parcel/transformer-posthtml": "2.11.0",
-        "@parcel/transformer-raw": "2.11.0",
-        "@parcel/transformer-react-refresh-wrap": "2.11.0",
-        "@parcel/transformer-svg": "2.11.0"
+        "@parcel/bundler-default": "2.15.2",
+        "@parcel/compressor-raw": "2.15.2",
+        "@parcel/namer-default": "2.15.2",
+        "@parcel/optimizer-css": "2.15.2",
+        "@parcel/optimizer-html": "2.15.2",
+        "@parcel/optimizer-image": "2.15.2",
+        "@parcel/optimizer-svg": "2.15.2",
+        "@parcel/optimizer-swc": "2.15.2",
+        "@parcel/packager-css": "2.15.2",
+        "@parcel/packager-html": "2.15.2",
+        "@parcel/packager-js": "2.15.2",
+        "@parcel/packager-raw": "2.15.2",
+        "@parcel/packager-svg": "2.15.2",
+        "@parcel/packager-wasm": "2.15.2",
+        "@parcel/reporter-dev-server": "2.15.2",
+        "@parcel/resolver-default": "2.15.2",
+        "@parcel/runtime-browser-hmr": "2.15.2",
+        "@parcel/runtime-js": "2.15.2",
+        "@parcel/runtime-rsc": "2.15.2",
+        "@parcel/runtime-service-worker": "2.15.2",
+        "@parcel/transformer-babel": "2.15.2",
+        "@parcel/transformer-css": "2.15.2",
+        "@parcel/transformer-html": "2.15.2",
+        "@parcel/transformer-image": "2.15.2",
+        "@parcel/transformer-js": "2.15.2",
+        "@parcel/transformer-json": "2.15.2",
+        "@parcel/transformer-node": "2.15.2",
+        "@parcel/transformer-postcss": "2.15.2",
+        "@parcel/transformer-posthtml": "2.15.2",
+        "@parcel/transformer-raw": "2.15.2",
+        "@parcel/transformer-react-refresh-wrap": "2.15.2",
+        "@parcel/transformer-svg": "2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-Npe0S6hVaqWEwRL+HI7gtOYOaoE5bJQZTgUDhsDoppWbau51jOlRYOZTXuvRK/jxXnze4/S1sdM24xBYAQ5qkw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.15.2.tgz",
+      "integrity": "sha512-yIFtxeLPLbTkpNuXGmnBX1U51unxv+gRoH/I5IcyD/vRL2Kp/cQU6YJWTSGK5sWG1Fgo+1Z2DeYp914Yd4a1WQ==",
       "dev": true,
       "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/cache": "2.15.2",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/events": "2.15.2",
+        "@parcel/feature-flags": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/graph": "3.5.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/package-manager": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/profiler": "2.15.2",
+        "@parcel/rust": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
-        "abortcontroller-polyfill": "^1.1.9",
-        "base-x": "^3.0.8",
-        "browserslist": "^4.6.6",
-        "clone": "^2.1.1",
-        "dotenv": "^7.0.0",
-        "dotenv-expand": "^5.1.0",
-        "json5": "^2.2.0",
-        "msgpackr": "^1.9.9",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2",
+        "base-x": "^3.0.11",
+        "browserslist": "^4.24.5",
+        "clone": "^2.1.2",
+        "dotenv": "^16.5.0",
+        "dotenv-expand": "^11.0.7",
+        "json5": "^2.2.3",
+        "msgpackr": "^1.11.2",
         "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/core/node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+    "node_modules/@parcel/core/node_modules/@parcel/cache": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.15.2.tgz",
+      "integrity": "sha512-xYVNKWUHT5hCxo+9nBy9xm7NVfk/jswo+SrU12pXtJm4S5kyK7/PaNkiXxnDu/Hiec2s9BqG/7ny5WBX+i/fAw==",
       "dev": true,
+      "dependencies": {
+        "@parcel/fs": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "lmdb": "2.8.5"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/fs": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
+      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/feature-flags": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/types-internal": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.15.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/node-resolver-core": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
+      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "nullthrows": "^1.1.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/package-manager": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.15.2.tgz",
+      "integrity": "sha512-0n8QupNyXp9CJZV6LohBpAqopLecQrave4kHG/T9CeCeqlJcQnYs+N+zio4mPlv7jXpnJHy+CF96Ce2wy/n1+Q==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/node-resolver-core": "3.6.2",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2",
+        "@swc/core": "^1.11.24",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.11.0.tgz",
-      "integrity": "sha512-4dJmOXVL5YGGQRRsQosQbSRONBcboB71mSwaeaEgz3pPdq9QXVPLACkGe/jTXSqa3OnAHu3g5vQLpE1g5xqBqw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.15.2.tgz",
+      "integrity": "sha512-lsIF59BgfLzN3SP5VM42pa9lilcotEoF42H2RgnqLe3KACcNcbbtvjyjlvac+iaSRix4gEkuZa6376X6p7DkFQ==",
       "dev": true,
       "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
+        "@mischnic/json-sourcemap": "^0.1.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/error-overlay": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.15.2.tgz",
+      "integrity": "sha512-bfDWkTQ4jCBUdOSynXo49pCPrVgtYSwobSxMeNhmwpdKbFvavj/09eZkAHikQgcrCF8gBwapik/U2YBTnFt0fg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2488,51 +2370,42 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.11.0.tgz",
-      "integrity": "sha512-K6SOjOrQsz1GdNl2qKBktq7KJ3Q3yxK8WXdmQYo10wG39dr051xtMb38aqieTp4eVhL8Yaq2iJgGkdr11fuBnA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.15.2.tgz",
+      "integrity": "sha512-CxXVuYz/K3sDIquM+3Pemxhppb8Q/mRayxqxZtXHoKbhiLBeyX+pLz2v9Hr0R7fiN6naV00IG48Zc5aArHXR4w==",
       "dev": true,
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/fs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.11.0.tgz",
-      "integrity": "sha512-zWckdnnovdrgdFX4QYuQV4bbKCsh6IYCkmwaB4yp47rhw1MP0lkBINLt4yFPHBxWXOpElCfxjL+z69c9xJQRBQ==",
+    "node_modules/@parcel/feature-flags": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.15.2.tgz",
+      "integrity": "sha512-6oiuLd3ypk4GY8X9/l/GrngzSddHW8yF8DrYA++TkaPDtTz4llanza/p7RIk/ltdV3hmBxnH4vjWtciJEcbQww==",
       "dev": true,
-      "dependencies": {
-        "@parcel/rust": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.11.0"
-      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.11.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.1.0.tgz",
-      "integrity": "sha512-d1dTW5C7A52HgDtoXlyvlET1ypSlmIxSIZOJ1xp3R9L9hgo3h1u3jHNyaoTe/WPkGVe2QnFxh0h+UibVJhu9vg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.5.2.tgz",
+      "integrity": "sha512-SsKKRPotNALU5R5r5WOsP+6FsuaNkk9L0Bmu1UzeyyrHiQPO1OVBYCsX+NtsGDAdDX7oOkGqgfkavJHrAG/BFA==",
       "dev": true,
       "dependencies": {
+        "@parcel/feature-flags": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2540,16 +2413,16 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.11.0.tgz",
-      "integrity": "sha512-HtMEdCq3LKnvv4T2CIskcqlf2gpBvHMm3pkeUFB/hc/7hW/hE1k6/HA2VOQvc0tBsaMpmEx7PCrfrH56usQSyA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.15.2.tgz",
+      "integrity": "sha512-naF3dXcvO1lZvtCi6kCTaXhB1cqRwWkRifQRfEei+yp0QZqZF9dmWwZzMOefst/PTl3RaW014vrwFtiegdqsbQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0"
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/events": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2557,15 +2430,15 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.11.0.tgz",
-      "integrity": "sha512-YA60EWbXi6cLOIzcwRC2wijotPauOGQbUi0vSbu0O6/mjQ68kWCMGz0hwZjDRQcPypQVJEIvTgMymLbvumxwhg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.15.2.tgz",
+      "integrity": "sha512-qioxe3Gw/khhrZXeF3tmJeChoq70prxGqVhJylsnGimxHbxjLo3i8Jo8Thi36GiGcOTYSeyF/2tMo9BW2t2vqA==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0"
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2589,40 +2462,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.11.0.tgz",
-      "integrity": "sha512-DEwBSKSClg4DA2xAWimYkw9bFi7MFb9TdT7/TYZStMTsfYHPWOyyjGR7aVr3Ra4wNb+XX6g4rR41yp3HD6KO7A==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.15.2.tgz",
+      "integrity": "sha512-2JtJjqKlJEv34OsZdyfAiRtTwNB/ulsStokCSB/fNCkfJPMtgWHDLFz17O7evJbWIoS1gQbIsmeS5GiMBfWdFw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/node-resolver-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.2.0.tgz",
-      "integrity": "sha512-XJRSxCkNbGFWjfmwFdcQZ/qlzWZd35qLtvLz2va8euGL7M5OMEQOv7dsvEhl0R+CC2zcnfFzZwxk78q6ezs8AQ==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -2630,292 +2481,128 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.11.0.tgz",
-      "integrity": "sha512-bV97PRxshHV3dMwOpLRgcP1QNhrVWh6VVDfm2gmWULpvsjoykcPS6vrCFksY5CpQsSvNHqJBzQjWS8FubUI76w==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.15.2.tgz",
+      "integrity": "sha512-czLiJPe2T2QXuGO3xBIM1a1OnR/UhTwY1efCZzo7CofzklNRu33CDLZuWC2Re/JK1+dO4fYBOs0rdWmGFB5acg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
+        "@parcel/utils": "2.15.2",
+        "browserslist": "^4.24.5",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.11.0.tgz",
-      "integrity": "sha512-c20pz4EFF5DNFmqYgptlIj49eT6xjGLkDTdHH3RRzxKovuSXWfYSPs3GED3ZsjVuQyjNQif+/MAk9547F7hrdQ==",
+    "node_modules/@parcel/optimizer-html": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.15.2.tgz",
+      "integrity": "sha512-7jcvytsOfvdpXIehkZDD9nYzF5V8Dk6JULffDPA03deB8aiFhvPPXr2gr5h3hc/ZvO220dfAJ63Ie622y0BNrQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "htmlnano": "^2.0.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "svgo": "^2.4.0"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.11.0.tgz",
-      "integrity": "sha512-jCaJww5QFG2GuNzYW8nlSW+Ea+Cv47TRnOPJNquFIajgfTLJ5ddsWbaNal0GQsL8yNiCBKWd1AV4W0RH9tG0Jg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.15.2.tgz",
+      "integrity": "sha512-KCm70vpyIPO9Ml1ZDp2zg8ghPFUDqZ5zu1ZwLwm3SpP/rZYIb6Y/hPTVz/D17yJp6m4bBUVPNLI6Nl2Li4rktg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0"
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.15.2"
       }
     },
-    "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.11.0.tgz",
-      "integrity": "sha512-TQpvfBhjV2IsuFHXUolbDS6XWB3DDR2rYTlqlA8LMmuOY7jQd9Bnkl4JnapzWm/bRuzRlzdGjjVCPGL8iShFvA==",
+    "node_modules/@parcel/optimizer-svg": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.15.2.tgz",
+      "integrity": "sha512-qyOt5BliHB1Dvi8c9h/95qzC80+7gw3ygMRM+avzuhESLlsGimktBBMHi+L6S1TQFjcHsorCkpcTfu48Vx6hUw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "svgo": "^2.4.0"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.11.0.tgz",
-      "integrity": "sha512-ftf42F3JyZxJb6nnLlgNGyNQ273YOla4dFGH/tWC8iTwObHUpWe7cMbCGcrSJBvAlsLkZfLpFNAXFxUgxdKyHQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.15.2.tgz",
+      "integrity": "sha512-Ej8Y0VkNRUl7jyX4Xd9C8vTHqHfPXH3kAaEndrc7K1ZfvGeIzw/7OytFJeyJ/KbEIW7XWWtd2r7KaFiEG/8SJA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "@swc/core": "^1.3.36",
+        "@parcel/utils": "2.15.2",
+        "@swc/core": "^1.11.24",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/package-manager": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.11.0.tgz",
-      "integrity": "sha512-QzdsrUYlAwIzb8by7WJjqYnbR1MoMKWbtE1MXUeYsZbFusV8B6pOH+lwqNJKS/BFtddZMRPYFueZS2N2fwzjig==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.11.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.11.0.tgz",
-      "integrity": "sha512-AyIxsp4eL8c22vp2oO2hSRnr3hSVNkARNZc9DG6uXxCc2Is5tUEX0I4PwxWnAx0EI44l+3zX/o414zT8yV9wwQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.15.2.tgz",
+      "integrity": "sha512-LZrFXC8bj7isdfKZIPS8OhFUWgZNmGXZJVfl7KLUD4D8GfNX0yKxBb4wtdfuQjlr1KMyw0WluchTXads4oVcMg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.15.2",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -2923,20 +2610,19 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.11.0.tgz",
-      "integrity": "sha512-ho5AQ70naTV8IqkKIbKtK+jsXQ5TJfFgtBvmJlyB3YydRMbIc+3g4G0xgIvf15V4uCMw9Md0Sv1W65nQXHPQoA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.15.2.tgz",
+      "integrity": "sha512-+uvMAZW3r2h1IS+UD3QfCmcFwJb3pPPyQOGK/ks5pYcY0Bqxfvco+5vAbMBofZ6b6RS9YCUvBtJbe1FFx4A3Jw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -2944,67 +2630,40 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.11.0.tgz",
-      "integrity": "sha512-SxjCsd0xQfg5H73YtVJj9VOpr9s0rwMsSoeykjkatbkEla9NsZajsUkd/bfYf+/0WvEKOrB8oUBo15HkGOgKug==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.15.2.tgz",
+      "integrity": "sha512-kEXuKduZH/ynxm5zOUZSp6kV+/eyKbHn+zILXfFB7VeHuNyATfm8GTcSUhLYFHAoOncXorE51KI6KDMuKPejjA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "globals": "^13.2.0",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "globals": "^13.24.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/packager-js/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@parcel/packager-js/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.11.0.tgz",
-      "integrity": "sha512-2/0JQ8DZrz7cVNXwD6OYoUUtSSnlr4dsz8ZkpFDKsBJhvMHtC78Sq+1EDixDGOMiUcalSEjNsoHtkpq9uNh+Xw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.15.2.tgz",
+      "integrity": "sha512-S4Gve8k9+qUj2c3wmbNmMQNqwsJ6E6o7ww/Z3CZ1M1i6UcegRVnK1usElw+6+j2L1sXdt/6pIUZvCg3DA9j3sA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3012,19 +2671,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.11.0.tgz",
-      "integrity": "sha512-2wQBkzLwcaWFGWz8TP+bgsXgiueWPzrjKsWugWdDfq0FbXh8XVeR/599qnus3RFHZy4cH6L6yq/7zxcljtxK8A==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.15.2.tgz",
+      "integrity": "sha512-oTdoPl1mcJ0JeKPz5/ZZFlM+UM9YNsutRm8l6H2k6dcht2mbOt8e0OZQcRIiHmTcY8eEsF3bXmo/qXWB+PcihA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "posthtml": "^0.16.4"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3032,16 +2691,16 @@
       }
     },
     "node_modules/@parcel/packager-ts": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.11.0.tgz",
-      "integrity": "sha512-j9TxAz65nHYo/c2aEwGcPUE2F6qOenr6vm1YR8jHnahrW9LEPXkZjSJA1i85Hs+ihAQKpSatMJzO5RojBgcevw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.15.2.tgz",
+      "integrity": "sha512-y69nPhsTzQ2C148JR8roLr2+ldUnq3e46A9uaVC05Vrlbqwkc/obJNU0u6tekbxEBKI7agA8YZPxYGOai1wOLg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3049,16 +2708,16 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.11.0.tgz",
-      "integrity": "sha512-tTy4EbDXeeiZ0oB7L2FWaHSD1mbmYZP6R5HXqkvc5dECGUKPU5Jz6ek2C5AM+HfQdQLKXPQ/Xw3eJnI/AmctVg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.15.2.tgz",
+      "integrity": "sha512-LqDdXeC/cbjGc4qZjOJvpx4PmuQL0+kQVmO3AvnUIee+C2T2LgdTG7qhzJGJcihdvkvxZjKZI9fQgrjy9EFDuA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">=12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">=16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3066,15 +2725,15 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.11.0.tgz",
-      "integrity": "sha512-9npuKBlhnPn7oeUpLJGecceg16GkXbvzbr6MNSZiHhkx3IBeITHQXlZnp2zAjUOFreNsYOfifwEF2S4KsARfBQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.15.2.tgz",
+      "integrity": "sha512-5ii1OpD/lGdpvy5AS1jChpCwEZP0eFaucy8szOjmfl4oZIeaHRHbZ5R0/3O1Hy8tY1IJF87HUKd+XV0iyD48zA==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.11.0"
+        "@parcel/types": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3082,17 +2741,18 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.11.0.tgz",
-      "integrity": "sha512-s10SS09prOdwnaAcjK8M5zO8o+zPJJW5oOqXPNdf6KH4NGD/ue7iOk2xM8QLw6ulSwxE7NDt++lyfW3AXgCZwg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.15.2.tgz",
+      "integrity": "sha512-hLTI6TIRr/tGgjTbsCqW4Avl2x8FMAHLDlDhNYjivX6ccfZmilEJnIcdKr2QtdgcaSulfRLTd5bt6uJWJ2ecKg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/events": "2.15.2",
+        "@parcel/types-internal": "2.15.2",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3100,21 +2760,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.11.0.tgz",
-      "integrity": "sha512-hY0iO0f+LifgJHDUIjGQJnxLFSkk2jlbfy+kIaft5oI3/IM+UljecfGO+14XH8mYlqRXXPsT09TJe8ZKQzp4ZQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.15.2.tgz",
+      "integrity": "sha512-R2WuHr+0FafsR9WNibR8ssyX8bHwXzMA91OdmeLMaAG5Dc/xv6yTIZuvOCdlCAfbBkcRiMnLWTQ3hQI1bqkC4g==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "chalk": "^4.1.0",
-        "cli-progress": "^3.12.0",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3138,17 +2797,19 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.11.0.tgz",
-      "integrity": "sha512-T4ue1+oLFNdcd9maw8QWQuxzOS2kX2jOrSvYKwYd9oGnqiAr1rpiHYYKJhHng+PF5ybwWkj8dUJfGh2NoQysJA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.15.2.tgz",
+      "integrity": "sha512-xJzb+IfcZfD2Ml4GYhHFovQ4vbWpFP/bd9cM9TuzyfCbaaf0NEN18uY3kRFCUDYOWs7aLOMzqL3eI5Hw6zh+Pw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/codeframe": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3156,19 +2817,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.11.0.tgz",
-      "integrity": "sha512-33q4ftO26OPWHkUpEm0bzzSjW2kHEh6q/JFePwf8W6APTQVruj4mV46+Fh6rxX42ixs92K/QoiE0gYgWZQVDHA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.15.2.tgz",
+      "integrity": "sha512-jtmNPMXVuuqO4WmIgYifAtKhMWblAZmRnqc5dVZfUBWPeqGKrbH2k89cYtZfvMbLon8/Glv6WDOt91oyDfjuKg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3176,17 +2837,63 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.11.0.tgz",
-      "integrity": "sha512-suZNN2lE5W48LPTwAbG7gnj1IeubkCVEm0XspWXcXUtCzglimNJ8PVVBGx171o5CqDpdbGF3AqHjG9N3uOwXag==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.15.2.tgz",
+      "integrity": "sha512-CuCCPEu3jwyLplbLDrahq0CstmIHchKefmX0JGpqCJBJBVdO89SHV5hUr8Se7hfy8uamD41wW10d51oAmyjXMA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/plugin": "2.11.0"
+        "@parcel/node-resolver-core": "3.6.2",
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/resolver-default/node_modules/@parcel/fs": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
+      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/feature-flags": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/types-internal": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.15.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
+      }
+    },
+    "node_modules/@parcel/resolver-default/node_modules/@parcel/node-resolver-core": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
+      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "nullthrows": "^1.1.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3194,17 +2901,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.11.0.tgz",
-      "integrity": "sha512-uVwNBtoLMrlPHLvRS05BVhLseduMOpZT36yiIjS0YSBJcC6/otI9AY7ZiDPYmrB5xTqM0R+D554JhPaJHCuocw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.15.2.tgz",
+      "integrity": "sha512-4QtuKAT3NphDrGpRVXyGOrG/gR6cjLIqPkqamTEuAVc13bmjK9XJ5Q4l1L3kjIIlQrRPg9MlHJcZ7VR3PuWWRQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3212,39 +2919,39 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.11.0.tgz",
-      "integrity": "sha512-fH3nJoexINz7s4cDzp0Vjsx0k1pMYSa5ch38LbbNqCKTermy0pS0zZuvgfLfHFFP+AMRpFQenrF7h7N3bgDmHw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.15.2.tgz",
+      "integrity": "sha512-5GGL/7rH6N54u7lAjX8mJKsumFiCyUcpz9wbygG4gkzMcRmGRnp+tctKI9f0GPfcMfKhdypOHfduc5SAuMX03w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.11.0.tgz",
-      "integrity": "sha512-Kfnc7gLjhoephLMnjABrkIkzVfzPrpJlxiJFIleY2Fm57YhmCfKsEYxm3lHOutNaYl1VArW0LKClPH/VHG9vfQ==",
+    "node_modules/@parcel/runtime-rsc": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.15.2.tgz",
+      "integrity": "sha512-k0cYvrPUXpvV+neplTkJ1P/LkJzQmtF4eU3js+/kzyOU3zhUSgrLNHJmj6ibuWVYHENW2QtasvpsXjvE2knqTg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": "^0.9.0"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3252,18 +2959,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.11.0.tgz",
-      "integrity": "sha512-c8MaSpSbXIKuN5sA/g4UsrsH1BtBZ6Em+eSxt9AYbdPtWrW+qwCioNVZj9lugBRUzDMjVfJz0yK59nS42hABvw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.15.2.tgz",
+      "integrity": "sha512-5+nV46pqa+7xFscLr4NRSeyXR8i+PSOoECRUzrv4UJRVbeCeE4bfqMYXs+rMbSrBillOLZyydNUQUT56xo9W6A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3271,12 +2978,190 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.11.0.tgz",
-      "integrity": "sha512-UkLWdHOD8Md2YmJDPsqd3yIs9chhdl/ATfV/B/xdPKGmqtNouYpDCRlq+WxMt3mLoYgHEg9UwrWLTebo2rr2iQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.15.2.tgz",
+      "integrity": "sha512-6ZIVsSnkwxvDDVaxiYK4bWtVaJBYaFQuRvcxfCMQHEzFpWl9mdZVbCs3+g69Ere7a3e2sk87B41d/FIhoaz5xw==",
       "dev": true,
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/rust-darwin-arm64": "2.15.2",
+        "@parcel/rust-darwin-x64": "2.15.2",
+        "@parcel/rust-linux-arm-gnueabihf": "2.15.2",
+        "@parcel/rust-linux-arm64-gnu": "2.15.2",
+        "@parcel/rust-linux-arm64-musl": "2.15.2",
+        "@parcel/rust-linux-x64-gnu": "2.15.2",
+        "@parcel/rust-linux-x64-musl": "2.15.2",
+        "@parcel/rust-win32-x64-msvc": "2.15.2"
+      },
+      "peerDependencies": {
+        "napi-wasm": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "napi-wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@parcel/rust-darwin-arm64": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.15.2.tgz",
+      "integrity": "sha512-IK5mo/7bNym1ODMWD92D2URGcAq2K/9BasRlfjWI/Gh74l3lH4EFadUfgM88L+MVCV3WTg8ht5ZA0Iyp+IQ1JQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-darwin-x64": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.15.2.tgz",
+      "integrity": "sha512-J30ukJXCzXsYNlYvYsaPEAEzfCZGXVIkXtPSVpWPwcaReqFUyT2bm4I8DHoeas0JwMNaeNlJhksaJA/iomqlwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm-gnueabihf": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.15.2.tgz",
+      "integrity": "sha512-WpPddkviw8IkRRnT/dRyD3Uzvy6Yuoy5vvtDmpnrR2bJnEz5uQI3TlhMtQo7R+j6aIrDsGFJKBeo9Z0ga0ebNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm64-gnu": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.15.2.tgz",
+      "integrity": "sha512-RzD7Gw0QqyUoWaVrtCU+v5J5pg6bybVNknqlEY4jfcJDgJHsM1V91DwJwxnI4ikG/uMedl0I40dl59x/Vo01Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm64-musl": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.15.2.tgz",
+      "integrity": "sha512-mWoL7kCITrEOO0GQ+LqGUylX+6b3nsV60Lzrz2N0Pgzz3EbGS0d4gDKkjxpi6BoR+h4KL7nLhj4hhbm0OHIc4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-x64-gnu": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.15.2.tgz",
+      "integrity": "sha512-aI8bKZTEZNYmgURiAfrgpmaoEArnMRvosfsOKnGykTjmHgsBxO/CGguFj5a4wlAZTVWcTGfs4krnUKtF9Hw6Rw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-x64-musl": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.15.2.tgz",
+      "integrity": "sha512-FpQOraPTjGfbHipjdbYpQLlMIRDoVL+Kl9ak+6mt0SbvP3QaXGosQXyhw0ZoNszqVLjIwC0OHEjAHdtcO6ZUvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-win32-x64-msvc": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.15.2.tgz",
+      "integrity": "sha512-aSXkPc+KYAT6MnYgw2urXuDvipPkD90uJBKtSn3MY+fGOfzEluK7j0F5NdH88oTzrGVhRQxnxfe3Fc+IRhsaFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       },
       "funding": {
         "type": "opencollective",
@@ -3296,23 +3181,23 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.11.0.tgz",
-      "integrity": "sha512-WKGblnp7r426VG+cpeQzc6dj/30EoUaYwyl4OEaigQSJizyuPWTBWTz6FUw+ih1/sg37h+D1BIh9C2FsVzpzbw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.15.2.tgz",
+      "integrity": "sha512-9oGx0wJhKY+Lh6PLY05m36IS6r6oOxpAQZhna2S5AYcfcf10ZsL8afOJTE8JBXbfg35dp97jeB4iuSHYTXr6NA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "browserslist": "^4.6.6",
-        "json5": "^2.2.0",
+        "@parcel/utils": "2.15.2",
+        "browserslist": "^4.24.5",
+        "json5": "^2.2.3",
         "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3320,22 +3205,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.11.0.tgz",
-      "integrity": "sha512-nFmBulF/ErNoafO87JbVrBavjBMNwE/kahbCRVxc2Mvlphz4F4lBW4eDRS5l4xBqFJaNkHr9R55ehLBBilF4Jw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.15.2.tgz",
+      "integrity": "sha512-NlybdCOr8r0LiPc7FIkeZp0mjfVB0Ht9B9eM3gUf2rOA1iM9/KGZNlu1AKVInyLRerybFqrGwHgx/qMGmbL3JA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
+        "@parcel/utils": "2.15.2",
+        "browserslist": "^4.24.5",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3343,24 +3228,18 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.11.0.tgz",
-      "integrity": "sha512-90vp7mbvvfqPr9XIINpMcELtywj56f1bxfOkLQgWU1bm22H0FT3i5dqdac++2My0IGDvMwhAEjQfbn4pA579NQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.15.2.tgz",
+      "integrity": "sha512-P0xptyNVKTgXr6HovvL3kCUw7eA3s2aZpAdliOhnFfzXUCG6Na/XN8TW5TOiNo41bcxsYwLpfrZz0N20AVJ4qw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2",
-        "srcset": "4"
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3368,66 +3247,83 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.11.0.tgz",
-      "integrity": "sha512-QiZj18UHf3lVFsi65Vz8YbS3ydx9Pe9x8ktMxE1oh9qpznN8lD7gE/Z9DxuTZB84EZ9pKytKwcv5WGXP25xIFg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.15.2.tgz",
+      "integrity": "sha512-5WpKkEDMppaO21MO/5Rikr+DDRjkh3mPalpnH/DQLNEv0fKOakSNWDRR7FuV5ozSVREeQurTvbb4tAFAxOQx1w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.11.0.tgz",
-      "integrity": "sha512-G1sv0n8/fJqHqwUs0iVnVdmRY0Kh8kWaDkuWcU/GJBHMGhUnLXKdNwxX2Av9UdBL14bU1nTINfr9qOfnQotXWg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.15.2.tgz",
+      "integrity": "sha512-zVDc5Pc3/Cbn3GGsGjj+k/WjQLJCdwsKlYfpYiTXvSuXDpb4FCcYgr6F+wbSHb+/VikYIVH1RwH4kjCuIuNtew==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2",
         "@swc/helpers": "^0.5.0",
-        "browserslist": "^4.6.6",
+        "browserslist": "^4.24.5",
         "nullthrows": "^1.1.1",
-        "regenerator-runtime": "^0.13.7",
-        "semver": "^7.5.2"
+        "regenerator-runtime": "^0.14.1",
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.11.0.tgz",
-      "integrity": "sha512-Wt/wgSBaRWmPL4gpvjkV0bCBRxFOtsuLNzsm8vYA5poxTFhuLY+AoyQ8S2+xXU4VxwBfdppfIr2Ny3SwGs8xbQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.15.2.tgz",
+      "integrity": "sha512-ycGhhk+DeipU0jtdGZesIx0X++h3qLkT77N6B2cTyD+BXAlKYUh++QIaLyDgTu7VwqSIt5msDg5jLWdamH7Rkw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "json5": "^2.2.0"
+        "@parcel/plugin": "2.15.2",
+        "json5": "^2.2.3"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-node": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.15.2.tgz",
+      "integrity": "sha512-H3IsKE2nVSEnqQH0DtjHQTTPqRw3gdXv9dROlwkU53O3cAIAtHDJYWmmDLMqhLl68vOYTvlkDT03rGrjnk8rDg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.15.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3435,23 +3331,23 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.11.0.tgz",
-      "integrity": "sha512-Ugy8XHBaUptGotsvwzq7gPCvkCopTIqqZ0JZ40Jmy9slGms8wnx06pNHA1Be/RcJwkJ2TbSu+7ncZdgmP5x5GQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.15.2.tgz",
+      "integrity": "sha512-3vLJqsFhOwsUS6lFnBZhU//OrfdLPM4uPBsm7XDLl45B2+FcW3T2H32uSGW6Ue1q1MawkVeNShuy293luh7gmA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "clone": "^2.1.1",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "clone": "^2.1.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3459,22 +3355,17 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.11.0.tgz",
-      "integrity": "sha512-dMK4p1RRAoIJEjK/Wz9GOLqwHqdD/VQDhMPk+6sUKp5zf2MhSohUstpp5gKsSZivCM3PS2f8k9rgroacJ/ReuA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.15.2.tgz",
+      "integrity": "sha512-khdk3IfQLnlryu695kEDQHsvw02jGSJsbgqHoOdIxEbMltxB1JMfJBOOiTm+JEXXQlgD1ttX59CQD4vC7sIT0Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3482,16 +3373,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.11.0.tgz",
-      "integrity": "sha512-2ltp3TgS+cxEqSM1vk5gDtJrYx4KMuRRtbSgSvkdldyOgPhflnLU3/HRz72hXSNGqYOV0/JN0+ocsfPnqR00ug==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.15.2.tgz",
+      "integrity": "sha512-c/7rzEnpWJJmQbZiwFgL57ETUIIiiySBoVmtuF22yNjGQc1Znthg/ee8pT755UfE1hDCT6Kh/XLWv1Bt3C64CQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3499,18 +3390,19 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.11.0.tgz",
-      "integrity": "sha512-6pY0CdIgIpXC6XpsDWizf+zLgiuEsJ106HjWLwF7/R72BrvDhLPZ6jRu4UTrnd6bM89KahPw9fZZzjKoA5Efcw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.15.2.tgz",
+      "integrity": "sha512-ReH5qjJbT1Tj7ZYi1KIck2amNTiWqY6m31Ml3I6JeApg7djnz+EwbzPmbpKkcFmR+wxt82DtQdXO3Y7BOJsZDQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "react-refresh": "^0.9.0"
+        "@parcel/error-overlay": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "react-refresh": "^0.16.0"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3518,23 +3410,18 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.11.0.tgz",
-      "integrity": "sha512-GrTNi04OoQSXsyrB7FqQPeYREscEXFhIBPkyQ0q7WDG/yYynWljiA0kwITCtMjPfv2EDVks292dvM3EcnERRIA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.15.2.tgz",
+      "integrity": "sha512-R5Q0JgDtywSmojvqqa6TDmXDbKCfBBgu4tR0mzo3VicEObmiatRT49BFWHbdenfTf5tKpRplfH88leMPuDVVAg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
+        "@parcel/rust": "2.15.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3542,21 +3429,21 @@
       }
     },
     "node_modules/@parcel/transformer-typescript-types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.11.0.tgz",
-      "integrity": "sha512-d9iTDMtFyAZkqxMGguBNGD6q9QKvLd0deUs7Ax8jdhYMjxwAEGU48mg8vjPjumItgA/2mD4ptMJjQB25mtetfA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.15.2.tgz",
+      "integrity": "sha512-fEHw2ONaSPmWHCwtKx8MEc6zELDoAwxHoHFe0uhuMWBERkM2Ntgig7TEl8dQ0Y2UrQdOnPrJlsKu6TsPmr02+g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/plugin": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/ts-utils": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/ts-utils": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.15.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3567,15 +3454,15 @@
       }
     },
     "node_modules/@parcel/ts-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.11.0.tgz",
-      "integrity": "sha512-przIVpyuyAk1enpbbjVxn146dY25L1qcD/qU5HOCK8oH3ddQ0n1RgpXT9HKVpqteOnQIHDupUrZLArK6aqEnwA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.15.2.tgz",
+      "integrity": "sha512-xdehXMsxjs56+vGamD3vKAO+e8cbUlxUOFPCVz6nuvQ9KfQ+PgpLQwPuPvvGdDkj75YbzCJks19C9lvpIg251g==",
       "dev": true,
       "dependencies": {
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3586,37 +3473,44 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-lN5XlfV9b1s2rli8q1LqsLtu+D4ZwNI3sKmNcL/3tohSfQcF2EgF+MaiANGo9VzXOzoWFHt4dqWjO4OcdyC5tg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.15.2.tgz",
+      "integrity": "sha512-APVvBVVG8RIMLN5hERa2POkPkEtrNUqRbQlKpoNYlIYZaYxKzb9+4MH4cVkmkGfYk3FGU3K5RnxSxMMWsu4tdw==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
+        "@parcel/types-internal": "2.15.2",
+        "@parcel/workers": "2.15.2"
+      }
+    },
+    "node_modules/@parcel/types-internal": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.15.2.tgz",
+      "integrity": "sha512-nmMpYeG4le49nvr8FsJYGEwhCZxcrm89tvkX8xGod1yXcShEZNWVVY9ezZLKxMrVMdBveqNUW8IZCij5iFDqdQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/feature-flags": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.11.0",
-        "utility-types": "^3.10.0"
+        "utility-types": "^3.11.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-AcL70cXlIyE7eQdvjQbYxegN5l+skqvlJllxTWg4YkIZe9p8Gmv74jLAeLWh5F+IGl5WRn0TSy9JhNJjIMQGwQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.15.2.tgz",
+      "integrity": "sha512-SQ77yZyeLZf5Teq5aMAViuXKoN7JRnYZ7Pdere1FD8ZuS7E34THA4jjJKxKu9Bqtezgm+gpN1gMbSKMBfbmIZA==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/markdown-ansi": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/codeframe": "2.15.2",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/markdown-ansi": "2.15.2",
+        "@parcel/rust": "2.15.2",
         "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3914,27 +3808,27 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.11.0.tgz",
-      "integrity": "sha512-wjybqdSy6Nk0N9iBGsFcp7739W2zvx0WGfVxPVShqhz46pIkPOiFF/iSn+kFu5EmMKTRWeUif42+a6rRZ7pCnQ==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.15.2.tgz",
+      "integrity": "sha512-uQWM3Zzkk+vzFYrLQvU/oeM1LC6/EDPvpdgtvdwkUqYC6O1Oei+9cWz6Uv5UDCwizeJKt+3PyE2rB9idbEkmsQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/profiler": "2.15.2",
+        "@parcel/types-internal": "2.15.2",
+        "@parcel/utils": "2.15.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/@petamoriken/float16": {
@@ -5097,14 +4991,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.106.tgz",
-      "integrity": "sha512-++QPSPkFq2qELYVScxNHJC42hKQChjiTWS2P0QQ5JWT4NHb9lmNSfrc1ylFIyImwRnxsW2MTBALLYLf95EFAsg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.29.tgz",
+      "integrity": "sha512-g4mThMIpWbNhV8G2rWp5a5/Igv8/2UFRJx2yImrLGMgrDDYZIopqZ/z0jZxDgqNA1QDx93rpwNF7jGsxVWcMlA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@swc/counter": "^0.1.1",
-        "@swc/types": "^0.1.5"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.21"
       },
       "engines": {
         "node": ">=10"
@@ -5114,19 +5008,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.106",
-        "@swc/core-darwin-x64": "1.3.106",
-        "@swc/core-linux-arm-gnueabihf": "1.3.106",
-        "@swc/core-linux-arm64-gnu": "1.3.106",
-        "@swc/core-linux-arm64-musl": "1.3.106",
-        "@swc/core-linux-x64-gnu": "1.3.106",
-        "@swc/core-linux-x64-musl": "1.3.106",
-        "@swc/core-win32-arm64-msvc": "1.3.106",
-        "@swc/core-win32-ia32-msvc": "1.3.106",
-        "@swc/core-win32-x64-msvc": "1.3.106"
+        "@swc/core-darwin-arm64": "1.11.29",
+        "@swc/core-darwin-x64": "1.11.29",
+        "@swc/core-linux-arm-gnueabihf": "1.11.29",
+        "@swc/core-linux-arm64-gnu": "1.11.29",
+        "@swc/core-linux-arm64-musl": "1.11.29",
+        "@swc/core-linux-x64-gnu": "1.11.29",
+        "@swc/core-linux-x64-musl": "1.11.29",
+        "@swc/core-win32-arm64-msvc": "1.11.29",
+        "@swc/core-win32-ia32-msvc": "1.11.29",
+        "@swc/core-win32-x64-msvc": "1.11.29"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": ">=0.5.17"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -5135,9 +5029,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.106.tgz",
-      "integrity": "sha512-XYcbViNyHnnm7RWOAO1YipMmthM7m2aXF32b0y+JMLYFBEyFpjVX9btLkzeL7wRx/5B3I35yJNhE+xyx0Q1Gkw==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.29.tgz",
+      "integrity": "sha512-whsCX7URzbuS5aET58c75Dloby3Gtj/ITk2vc4WW6pSDQKSPDuONsIcZ7B2ng8oz0K6ttbi4p3H/PNPQLJ4maQ==",
       "cpu": [
         "arm64"
       ],
@@ -5151,9 +5045,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.106.tgz",
-      "integrity": "sha512-YKDPhUdfuwhmOUS9+CaIwl/0Tp+f1b73BH2EIESuxSNsogZf18a8HQ8O0fQEwdiwmA5LEqw47cj+kfOWV/0+kw==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.29.tgz",
+      "integrity": "sha512-S3eTo/KYFk+76cWJRgX30hylN5XkSmjYtCBnM4jPLYn7L6zWYEPajsFLmruQEiTEDUg0gBEWLMNyUeghtswouw==",
       "cpu": [
         "x64"
       ],
@@ -5167,9 +5061,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.106.tgz",
-      "integrity": "sha512-bHxxJXogvFfocLL5inZxxtx/x/WgKozigp80Vbx0viac1fPDJrqKBw2X4MzpMiuTRAGVQ03jJI6pDwbSBf+yDw==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.29.tgz",
+      "integrity": "sha512-o9gdshbzkUMG6azldHdmKklcfrcMx+a23d/2qHQHPDLUPAN+Trd+sDQUYArK5Fcm7TlpG4sczz95ghN0DMkM7g==",
       "cpu": [
         "arm"
       ],
@@ -5183,9 +5077,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.106.tgz",
-      "integrity": "sha512-c7jue++CHLgtpeaakEukoCLT9eNrImizbleE9Y7Is8CHqLq/7DG4s+7ma9DFKXIzW2MpTg9byIEQfpqSphVW6A==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.29.tgz",
+      "integrity": "sha512-sLoaciOgUKQF1KX9T6hPGzvhOQaJn+3DHy4LOHeXhQqvBgr+7QcZ+hl4uixPKTzxk6hy6Hb0QOvQEdBAAR1gXw==",
       "cpu": [
         "arm64"
       ],
@@ -5199,9 +5093,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.106.tgz",
-      "integrity": "sha512-51EaC3Q8qAhLtWVnAVqoYX/gk3tK31cCBzUpwCcmhianhEBM2/WtKRAS4MqPhE8VVZuN3WjO2c2JaF2mX0yuoA==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.29.tgz",
+      "integrity": "sha512-PwjB10BC0N+Ce7RU/L23eYch6lXFHz7r3NFavIcwDNa/AAqywfxyxh13OeRy+P0cg7NDpWEETWspXeI4Ek8otw==",
       "cpu": [
         "arm64"
       ],
@@ -5215,9 +5109,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.106.tgz",
-      "integrity": "sha512-tOUi8BB6jAeCXgx7ESLNnX7nrbMVKQ/XajK77v7Ad4SXf9HYArnimBJpXUUyVFJTXLSv4e6c7s6XHHqXb5Lwcg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.29.tgz",
+      "integrity": "sha512-i62vBVoPaVe9A3mc6gJG07n0/e7FVeAvdD9uzZTtGLiuIfVfIBta8EMquzvf+POLycSk79Z6lRhGPZPJPYiQaA==",
       "cpu": [
         "x64"
       ],
@@ -5231,9 +5125,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.106.tgz",
-      "integrity": "sha512-binLw4Lbd83NPy4/m/teH2nbaifxveSD+sKDvpxywRbvYW2I0w/iCBpUBcbnl16TQF4TPOGpq5YwG9lVxPVw5g==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.29.tgz",
+      "integrity": "sha512-YER0XU1xqFdK0hKkfSVX1YIyCvMDI7K07GIpefPvcfyNGs38AXKhb2byySDjbVxkdl4dycaxxhRyhQ2gKSlsFQ==",
       "cpu": [
         "x64"
       ],
@@ -5247,9 +5141,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.106.tgz",
-      "integrity": "sha512-n4ttBWr8tM7DPzwcEOIBTyTMHZTzCmbic/HTtxEsPyMAf/Daen+yrTKzjPP6k2usfSrjkxA780RSJJxI1N8r2w==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.29.tgz",
+      "integrity": "sha512-po+WHw+k9g6FAg5IJ+sMwtA/fIUL3zPQ4m/uJgONBATCVnDDkyW6dBA49uHNVtSEvjvhuD8DVWdFP847YTcITw==",
       "cpu": [
         "arm64"
       ],
@@ -5263,9 +5157,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.106.tgz",
-      "integrity": "sha512-GhDNIwxE5FhkujESI6h/4ysT3wxwmrzTUlZYaR8rRui6a6SdX9feIPUHPEE5o5hpyp+xqlmvRxKkRxOnwsq8iA==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.29.tgz",
+      "integrity": "sha512-h+NjOrbqdRBYr5ItmStmQt6x3tnhqgwbj9YxdGPepbTDamFv7vFnhZR0YfB3jz3UKJ8H3uGJ65Zw1VsC+xpFkg==",
       "cpu": [
         "ia32"
       ],
@@ -5279,9 +5173,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.106",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.106.tgz",
-      "integrity": "sha512-2M6yWChuMS1+/MPo3Dor0SOMkvmiugonWlzsZBAu/oZboH2xKrHSRv7brsBujb2Oe47r+NsbV+vq9tnnP9Vl1Q==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.29.tgz",
+      "integrity": "sha512-Q8cs2BDV9wqDvqobkXOYdC+pLUSEpX/KvI0Dgfun1F+LzuLotRFuDhrvkU9ETJA6OnD2+Fn/ieHgloiKA/Mn/g==",
       "cpu": [
         "x64"
       ],
@@ -5295,33 +5189,27 @@
       }
     },
     "node_modules/@swc/counter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
-      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.3.tgz",
-      "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
-      "dev": true
-    },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
       "dev": true,
-      "engines": {
-        "node": ">=10.13.0"
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@types/async": {
@@ -5906,12 +5794,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
-      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -6196,12 +6078,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -6230,9 +6106,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
       "dev": true,
       "funding": [
         {
@@ -6249,10 +6125,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001716",
+        "electron-to-chromium": "^1.5.149",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6351,9 +6227,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001580",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
-      "integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "dev": true,
       "funding": [
         {
@@ -6444,9 +6320,9 @@
       }
     },
     "node_modules/clarifai-nodejs-grpc": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/clarifai-nodejs-grpc/-/clarifai-nodejs-grpc-11.3.4.tgz",
-      "integrity": "sha512-jruT7z+srEBwNyxgyY5NVgIoFekg/59aBYvzHLMhbT7aljlqSc2bcKrVaLs/pg7gDVgJjlTR7w1mhJjGxdRn0g==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/clarifai-nodejs-grpc/-/clarifai-nodejs-grpc-11.4.2.tgz",
+      "integrity": "sha512-MbL/bzhbdwiQ+/eYsInkd/eGTvFsWsnyGUSizmgk6KiOLTA5U7KsmKENnEc/gTYTwNNgJJovSx1xAbS3sugvOg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.4.2",
         "@grpc/proto-loader": "^0.5.5",
@@ -6465,18 +6341,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cli-progress": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.3"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/cliui": {
@@ -6631,12 +6495,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -6670,32 +6534,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -6717,153 +6555,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-select/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/csv-parse": {
       "version": "5.6.0",
@@ -6974,74 +6665,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7051,10 +6678,19 @@
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-      "dev": true
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/duck": {
       "version": "0.1.12",
@@ -7084,9 +6720,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.645",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
-      "integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==",
+      "version": "1.5.158",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.158.tgz",
+      "integrity": "sha512-9vcp2xHhkvraY6AHw2WMi+GDSLPX42qe2xjYaVoZqFRJiOcilVQFq9mZmpuHEQpzlgGDelKlV7ZiGcmMsc8WxQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7113,27 +6749,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -7210,9 +6825,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -7386,21 +7001,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7424,18 +7024,6 @@
       "dependencies": {
         "p-limit": "^3.0.2"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8001,6 +7589,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -8126,72 +7729,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/htmlnano": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.0.tgz",
-      "integrity": "sha512-jVGRE0Ep9byMBKEu0Vxgl8dhXYOUk0iNQ2pjsG+BcRB0u0oDF5A9p/iBGMg/PGKYUyMD0OAGu8dVT5Lzj8S58g==",
-      "dev": true,
-      "dependencies": {
-        "cosmiconfig": "^8.0.0",
-        "posthtml": "^0.16.5",
-        "timsort": "^0.3.0"
-      },
-      "peerDependencies": {
-        "cssnano": "^6.0.0",
-        "postcss": "^8.3.11",
-        "purgecss": "^5.0.0",
-        "relateurl": "^0.2.7",
-        "srcset": "4.0.0",
-        "svgo": "^3.0.2",
-        "terser": "^5.10.0",
-        "uncss": "^0.17.3"
-      },
-      "peerDependenciesMeta": {
-        "cssnano": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "purgecss": {
-          "optional": true
-        },
-        "relateurl": {
-          "optional": true
-        },
-        "srcset": {
-          "optional": true
-        },
-        "svgo": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "uncss": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      }
-    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -8310,12 +7847,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8344,12 +7875,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-json": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -8478,12 +8003,6 @@
         "base64-js": "^1.5.1"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -8499,12 +8018,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -8619,12 +8132,12 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.23.0.tgz",
-      "integrity": "sha512-SEArWKMHhqn/0QzOtclIwH5pXIYQOUEkF8DgICd/105O+GCgd7jxjNod/QPnBCSWvpRHQBGVz5fQ9uScby03zA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dev": true,
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -8634,21 +8147,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.23.0",
-        "lightningcss-darwin-x64": "1.23.0",
-        "lightningcss-freebsd-x64": "1.23.0",
-        "lightningcss-linux-arm-gnueabihf": "1.23.0",
-        "lightningcss-linux-arm64-gnu": "1.23.0",
-        "lightningcss-linux-arm64-musl": "1.23.0",
-        "lightningcss-linux-x64-gnu": "1.23.0",
-        "lightningcss-linux-x64-musl": "1.23.0",
-        "lightningcss-win32-x64-msvc": "1.23.0"
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.23.0.tgz",
-      "integrity": "sha512-kl4Pk3Q2lnE6AJ7Qaij47KNEfY2/UXRZBT/zqGA24B8qwkgllr/j7rclKOf1axcslNXvvUdztjo4Xqh39Yq1aA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
       ],
@@ -8666,9 +8180,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.23.0.tgz",
-      "integrity": "sha512-KeRFCNoYfDdcolcFXvokVw+PXCapd2yHS1Diko1z1BhRz/nQuD5XyZmxjWdhmhN/zj5sH8YvWsp0/lPLVzqKpg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
       ],
@@ -8686,9 +8200,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.23.0.tgz",
-      "integrity": "sha512-xhnhf0bWPuZxcqknvMDRFFo2TInrmQRWZGB0f6YoAsZX8Y+epfjHeeOIGCfAmgF0DgZxHwYc8mIR5tQU9/+ROA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
       ],
@@ -8706,9 +8220,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.23.0.tgz",
-      "integrity": "sha512-fBamf/bULvmWft9uuX+bZske236pUZEoUlaHNBjnueaCTJ/xd8eXgb0cEc7S5o0Nn6kxlauMBnqJpF70Bgq3zg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
       ],
@@ -8726,9 +8240,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.23.0.tgz",
-      "integrity": "sha512-RS7sY77yVLOmZD6xW2uEHByYHhQi5JYWmgVumYY85BfNoVI3DupXSlzbw+b45A9NnVKq45+oXkiN6ouMMtTwfg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
       ],
@@ -8746,9 +8260,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.23.0.tgz",
-      "integrity": "sha512-cU00LGb6GUXCwof6ACgSMKo3q7XYbsyTj0WsKHLi1nw7pV0NCq8nFTn6ZRBYLoKiV8t+jWl0Hv8KkgymmK5L5g==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
       ],
@@ -8766,9 +8280,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.23.0.tgz",
-      "integrity": "sha512-q4jdx5+5NfB0/qMbXbOmuC6oo7caPnFghJbIAV90cXZqgV8Am3miZhC4p+sQVdacqxfd+3nrle4C8icR3p1AYw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
       ],
@@ -8786,9 +8300,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.23.0.tgz",
-      "integrity": "sha512-G9Ri3qpmF4qef2CV/80dADHKXRAQeQXpQTLx7AiQrBYQHqBjB75oxqj06FCIe5g4hNCqLPnM9fsO4CyiT1sFSQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
       ],
@@ -8805,10 +8319,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.23.0.tgz",
-      "integrity": "sha512-1rcBDJLU+obPPJM6qR5fgBUiCdZwZLafZM5f9kwjFLkb/UBNIzmae39uCSmh71nzPCTXZqHbvwu23OWnWEz+eg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
       ],
@@ -8825,11 +8359,14 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/llamaindex": {
       "version": "0.2.13",
@@ -9093,17 +8630,6 @@
       "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -9205,14 +8731,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md-utils-ts/-/md-utils-ts-2.0.0.tgz",
       "integrity": "sha512-sMG6JtX0ebcRMHxYTcmgsh0/m6o8hGdQHFE2OgjvflRZlQM51CGGj/uuk056D+12BlCiW0aTpt/AdlDNtgQiew=="
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
@@ -9385,9 +8903,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/msgpackr": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
-      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
@@ -9554,9 +9072,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
     "node_modules/notion-md-crawler": {
@@ -9566,18 +9084,6 @@
       "dependencies": {
         "@notionhq/client": "^2.2.15",
         "md-utils-ts": "^2.0.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -9771,35 +9277,109 @@
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
     },
     "node_modules/parcel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.11.0.tgz",
-      "integrity": "sha512-H/RI1/DmuOkL8RuG/EpNPvtzrbF+7jA/R56ydEEm+lqFbYktKB4COR7JXdHkZXRgbSJyimrFB8d0r9+SaRnj0Q==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.15.2.tgz",
+      "integrity": "sha512-+ZFhK66uYSwEju8gd3d1qDrBO9JzUNjySnjVJHm9M2boHVDOJl0ZcMQNHTQD9Oyhcba6sf3yIQecjNK1+UvpWg==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.11.0",
-        "@parcel/core": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/reporter-cli": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/reporter-tracer": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.0.0",
+        "@parcel/config-default": "2.15.2",
+        "@parcel/core": "2.15.2",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/events": "2.15.2",
+        "@parcel/feature-flags": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/package-manager": "2.15.2",
+        "@parcel/reporter-cli": "2.15.2",
+        "@parcel/reporter-dev-server": "2.15.2",
+        "@parcel/reporter-tracer": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
         "get-port": "^4.2.0"
       },
       "bin": {
         "parcel": "lib/bin.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/fs": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
+      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/feature-flags": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/types-internal": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.15.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/node-resolver-core": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
+      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/rust": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "nullthrows": "^1.1.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/package-manager": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.15.2.tgz",
+      "integrity": "sha512-0n8QupNyXp9CJZV6LohBpAqopLecQrave4kHG/T9CeCeqlJcQnYs+N+zio4mPlv7jXpnJHy+CF96Ce2wy/n1+Q==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.15.2",
+        "@parcel/fs": "2.15.2",
+        "@parcel/logger": "2.15.2",
+        "@parcel/node-resolver-core": "3.6.2",
+        "@parcel/types": "2.15.2",
+        "@parcel/utils": "2.15.2",
+        "@parcel/workers": "2.15.2",
+        "@swc/core": "^1.11.24",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/parcel/node_modules/chalk": {
@@ -9828,24 +9408,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -10184,55 +9746,6 @@
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="
     },
-    "node_modules/posthtml": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
-      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
-      "dev": true,
-      "dependencies": {
-        "posthtml-parser": "^0.11.0",
-        "posthtml-render": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/posthtml-parser": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
-      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml/node_modules/posthtml-parser": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
-      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -10569,16 +10082,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true
-    },
     "node_modules/react-refresh": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
-      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10598,9 +10105,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
     "node_modules/require-directory": {
@@ -10763,12 +10270,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11076,25 +10580,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/srcset": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
-      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true
-    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -11267,33 +10752,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/svgo": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -11449,12 +10907,6 @@
         "readable-stream": "3"
       }
     },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
-    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -11606,9 +11058,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -11631,6 +11083,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-emitter": {
@@ -11899,9 +11363,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {
@@ -11918,8 +11382,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -12404,11 +11868,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
+  "exports": {
+    "import": "./dist/module.js",
+    "require": "./dist/main.js"
+  },
   "scripts": {
     "test": "vitest",
     "test:unit": "vitest unit.test",
@@ -36,8 +40,8 @@
   },
   "homepage": "https://github.com/Clarifai/clarifai-nodejs#readme",
   "devDependencies": {
-    "@parcel/packager-ts": "^2.11.0",
-    "@parcel/transformer-typescript-types": "^2.11.0",
+    "@parcel/packager-ts": "^2.15.2",
+    "@parcel/transformer-typescript-types": "^2.15.2",
     "@types/async": "^3.2.24",
     "@types/google-protobuf": "^3.15.12",
     "@types/js-yaml": "^4.0.9",
@@ -52,7 +56,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "parcel": "^2.11.0",
+    "parcel": "^2.15.2",
     "prettier": "3.2.4",
     "typedoc": "^0.25.12",
     "typedoc-plugin-include-example": "^1.2.0",
@@ -67,7 +71,7 @@
     "async": "^3.2.5",
     "axios": "^1.8.2",
     "chalk": "^5.3.0",
-    "clarifai-nodejs-grpc": "^11.3.4",
+    "clarifai-nodejs-grpc": "^11.4.2",
     "csv-parse": "^5.5.5",
     "from-protobuf-object": "^1.0.3",
     "google-protobuf": "^3.21.2",

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -1,4 +1,5 @@
-import {
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+const {
   GetDatasetRequest,
   GetModelRequest,
   GetWorkflowRequest,
@@ -8,38 +9,34 @@ import {
   ListModelsRequest,
   ListModulesRequest,
   ListWorkflowsRequest,
-  MultiDatasetResponse,
   PostDatasetsRequest,
   PostModelsRequest,
-  SingleModelResponse,
-  SingleWorkflowResponse,
-  SingleDatasetResponse,
   PostModulesRequest,
   DeleteDatasetsRequest,
   DeleteModelsRequest,
   DeleteWorkflowsRequest,
   DeleteModulesRequest,
   PostWorkflowsRequest,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+} = service_pb;
 import { UserError } from "../errors";
 import { ClarifaiAppUrl, ClarifaiUrlHelper } from "../urls/helper";
 import { promisifyGrpcCall } from "../utils/misc";
 import { AuthConfig, PaginationRequestParams } from "../utils/types";
 import { Lister } from "./lister";
-import {
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const {
   Model,
-  App as GrpcApp,
+  App: GrpcApp,
   Workflow,
   Module,
-  InstalledModuleVersion,
-  Concept,
   Dataset,
   WorkflowNode,
   ModelVersion,
   UserAppIDSet,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+} = resources_pb;
 import { TRAINABLE_MODEL_TYPES } from "../constants/model";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { validateWorkflow } from "../workflows/validate";
@@ -66,25 +63,28 @@ export type AppConfig =
     };
 
 export type ListDatasetsParam =
-  PaginationRequestParams<ListDatasetsRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListDatasetsRequest.AsObject>;
 export type ListModelsParam =
-  PaginationRequestParams<ListModelsRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListModelsRequest.AsObject>;
 export type ListWorkflowsParam =
-  PaginationRequestParams<ListWorkflowsRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListWorkflowsRequest.AsObject>;
 export type ListModulesParam =
-  PaginationRequestParams<ListModulesRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListModulesRequest.AsObject>;
 export type ListInstalledModuleVersionsParam =
-  PaginationRequestParams<ListInstalledModuleVersionsRequest.AsObject>;
-export type CreateDatasetParam = Omit<Partial<Dataset.AsObject>, "id">;
-export type CreateModelParam = Omit<Partial<Model.AsObject>, "id">;
+  PaginationRequestParams<service_pb.ListInstalledModuleVersionsRequest.AsObject>;
+export type CreateDatasetParam = Omit<
+  Partial<resources_pb.Dataset.AsObject>,
+  "id"
+>;
+export type CreateModelParam = Omit<Partial<resources_pb.Model.AsObject>, "id">;
 
 /**
  * App is a class that provides access to Clarifai API endpoints related to App information.
  * @noInheritDoc
  */
 export class App extends Lister {
-  private appInfo: GrpcApp;
-  public info: GrpcApp.AsObject;
+  private appInfo: resources_pb.App;
+  public info: resources_pb.App.AsObject;
 
   /**
    * Initializes an App object.
@@ -142,7 +142,7 @@ export class App extends Lister {
     pageNo?: number;
     perPage?: number;
   } = {}): AsyncGenerator<
-    MultiDatasetResponse.AsObject["datasetsList"],
+    service_pb.MultiDatasetResponse.AsObject["datasetsList"],
     void,
     unknown
   > {
@@ -187,7 +187,7 @@ export class App extends Lister {
     onlyInApp?: boolean;
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<Model.AsObject[], void, unknown> {
+  } = {}): AsyncGenerator<resources_pb.Model.AsObject[], void, unknown> {
     const listModels = promisifyGrpcCall(
       this.STUB.client.listModels,
       this.STUB.client,
@@ -245,7 +245,7 @@ export class App extends Lister {
     onlyInApp?: boolean;
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<Workflow.AsObject[], void, unknown> {
+  } = {}): AsyncGenerator<resources_pb.Workflow.AsObject[], void, unknown> {
     const request = fromPartialProtobufObject(ListWorkflowsRequest, params);
 
     const listWorkflows = promisifyGrpcCall(
@@ -298,7 +298,7 @@ export class App extends Lister {
     onlyInApp?: boolean;
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<Module.AsObject[], void, unknown> {
+  } = {}): AsyncGenerator<resources_pb.Module.AsObject[], void, unknown> {
     const listModules = promisifyGrpcCall(
       this.STUB.client.listModules,
       this.STUB.client,
@@ -347,7 +347,11 @@ export class App extends Lister {
     params?: ListInstalledModuleVersionsParam;
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<InstalledModuleVersion.AsObject[], void, unknown> {
+  } = {}): AsyncGenerator<
+    resources_pb.InstalledModuleVersion.AsObject[],
+    void,
+    unknown
+  > {
     const listInstalledModuleVersions = promisifyGrpcCall(
       this.STUB.client.listInstalledModuleVersions,
       this.STUB.client,
@@ -390,7 +394,7 @@ export class App extends Lister {
   }: {
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<Concept.AsObject[], void, unknown> {
+  } = {}): AsyncGenerator<resources_pb.Concept.AsObject[], void, unknown> {
     const listConcepts = promisifyGrpcCall(
       this.STUB.client.listConcepts,
       this.STUB.client,
@@ -428,7 +432,7 @@ export class App extends Lister {
   }: {
     datasetId: string;
     params?: CreateDatasetParam;
-  }): Promise<Dataset.AsObject> {
+  }): Promise<resources_pb.Dataset.AsObject> {
     const request = new PostDatasetsRequest();
     request.setUserAppId(this.userAppId);
 
@@ -470,7 +474,7 @@ export class App extends Lister {
   }: {
     modelId: string;
     params?: CreateModelParam;
-  }): Promise<Model.AsObject> {
+  }): Promise<resources_pb.Model.AsObject> {
     const request = new PostModelsRequest();
     request.setUserAppId(this.userAppId);
     const newModel = fromPartialProtobufObject(Model, {
@@ -509,7 +513,7 @@ export class App extends Lister {
   }: {
     moduleId: string;
     description: string;
-  }): Promise<Module.AsObject> {
+  }): Promise<resources_pb.Module.AsObject> {
     const request = new PostModulesRequest();
     request.setUserAppId(this.userAppId);
     const newModule = new Module();
@@ -547,7 +551,7 @@ export class App extends Lister {
     configFilePath: string;
     generateNewId?: boolean;
     display?: boolean;
-  }): Promise<Workflow.AsObject> {
+  }): Promise<resources_pb.Workflow.AsObject> {
     if (!fs.existsSync(configFilePath)) {
       throw new UserError(
         `Workflow config file not found at ${configFilePath}`,
@@ -560,9 +564,9 @@ export class App extends Lister {
     const workflow = validatedData["workflow"];
 
     // Get all model objects from the workflow nodes.
-    const allModels: Model.AsObject[] = [];
+    const allModels: resources_pb.Model.AsObject[] = [];
     for (const node of workflow.nodes) {
-      let modelObject: Model.AsObject | undefined;
+      let modelObject: resources_pb.Model.AsObject | undefined;
       const outputInfo = getYamlOutputInfoProto(node?.model?.outputInfo ?? {});
       try {
         const model = await this.model({
@@ -614,10 +618,10 @@ export class App extends Lister {
     }
 
     // Convert nodes to resources_pb2.WorkflowNodes.
-    const nodes: WorkflowNode.AsObject[] = [];
+    const nodes: resources_pb.WorkflowNode.AsObject[] = [];
     for (let i = 0; i < workflow["nodes"].length; i++) {
       const ymlNode = workflow["nodes"][i];
-      const node: WorkflowNode.AsObject = {
+      const node: resources_pb.WorkflowNode.AsObject = {
         id: ymlNode["id"],
         model: allModels[i],
         // TODO: setting default values, need to check for right values to set here
@@ -689,7 +693,7 @@ export class App extends Lister {
       userId: string;
       appId: string;
     };
-  }): Promise<SingleModelResponse.AsObject["model"]> {
+  }): Promise<service_pb.SingleModelResponse.AsObject["model"]> {
     const request = new GetModelRequest();
     if (modelUserAppId) {
       request.setUserAppId(
@@ -728,7 +732,7 @@ export class App extends Lister {
     workflowId,
   }: {
     workflowId: string;
-  }): Promise<SingleWorkflowResponse.AsObject["workflow"]> {
+  }): Promise<service_pb.SingleWorkflowResponse.AsObject["workflow"]> {
     const request = new GetWorkflowRequest();
     request.setUserAppId(this.userAppId);
     request.setWorkflowId(workflowId);
@@ -756,7 +760,7 @@ export class App extends Lister {
     datasetId,
   }: {
     datasetId: string;
-  }): Promise<SingleDatasetResponse.AsObject["dataset"]> {
+  }): Promise<service_pb.SingleDatasetResponse.AsObject["dataset"]> {
     const request = new GetDatasetRequest();
     request.setUserAppId(this.userAppId);
     request.setDatasetId(datasetId);

--- a/src/client/auth/helper.ts
+++ b/src/client/auth/helper.ts
@@ -1,5 +1,6 @@
-import resources_pb2 from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { grpc } from "clarifai-nodejs-grpc";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
+const { grpc } = clarifai_nodejs_grpc;
 import { V2Client } from "clarifai-nodejs-grpc/proto/clarifai/api/service_grpc_pb";
 import process from "process";
 import fs from "fs";
@@ -200,10 +201,10 @@ export class ClarifaiAuthHelper {
   getUserAppIdProto(
     userId?: string,
     appId?: string,
-  ): resources_pb2.UserAppIDSet {
+  ): resources_pb.UserAppIDSet {
     const effectiveUserId = userId ?? this.userId;
     const effectiveAppId = appId ?? this.appId;
-    const userAppIdSet = new resources_pb2.UserAppIDSet();
+    const userAppIdSet = new resources_pb.UserAppIDSet();
     userAppIdSet.setUserId(effectiveUserId);
     userAppIdSet.setAppId(effectiveAppId);
     return userAppIdSet;

--- a/src/client/auth/stub.ts
+++ b/src/client/auth/stub.ts
@@ -1,11 +1,13 @@
 import { ServiceError, status } from "@grpc/grpc-js";
 import { V2Client } from "clarifai-nodejs-grpc/proto/clarifai/api/service_grpc_pb";
 import { ClarifaiAuthHelper } from "./helper";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
 import { V2Stub } from "./register";
-import { grpc } from "clarifai-nodejs-grpc";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
+const { grpc } = clarifai_nodejs_grpc;
 import * as jspb from "google-protobuf";
-import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
+import status_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
+const { StatusCode } = status_code_pb;
 
 const throttleStatusCodes = new Set([
   StatusCode.CONN_THROTTLED,
@@ -35,7 +37,7 @@ type CallbackParameterType<T> = T extends (
 
 // Utility type to infer response type from callback
 type CallbackResponseType<T> = T extends (
-  error: grpc.ServiceError | null,
+  error: clarifai_nodejs_grpc.grpc.ServiceError | null,
   response: infer R,
 ) => void
   ? R
@@ -95,15 +97,15 @@ export class AuthorizedStub {
 
   async makeCallPromise<
     TRequest extends jspb.Message,
-    TResponseObject extends { status?: Status.AsObject },
+    TResponseObject extends { status?: status_pb.Status.AsObject },
     TResponse extends {
       toObject: (arg?: boolean) => TResponseObject;
     },
   >(
     endpoint: (
       request: TRequest,
-      metadata: grpc.Metadata,
-      options: Partial<grpc.CallOptions>,
+      metadata: clarifai_nodejs_grpc.grpc.Metadata,
+      options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
     ) => Promise<TResponse>,
     requestData: TRequest,
   ): Promise<TResponse> {
@@ -164,15 +166,15 @@ export class RetryStub extends AuthorizedStub {
 
   async makeCallPromise<
     TRequest extends jspb.Message,
-    TResponseObject extends { status?: Status.AsObject },
+    TResponseObject extends { status?: status_pb.Status.AsObject },
     TResponse extends {
       toObject: (arg?: boolean) => TResponseObject;
     },
   >(
     endpoint: (
       request: TRequest,
-      metadata: grpc.Metadata,
-      options: Partial<grpc.CallOptions>,
+      metadata: clarifai_nodejs_grpc.grpc.Metadata,
+      options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
     ) => Promise<TResponse>,
     requestData: TRequest,
   ): Promise<TResponse> {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -3,7 +3,7 @@ import { ClarifaiAuthHelper } from "./auth/helper";
 import { getFromDictOrEnv } from "../utils/misc";
 import { createStub } from "./auth/stub";
 import { V2Stub } from "./auth/register";
-import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb.js";
 import { AuthConfig } from "../utils/types";
 import * as jspb from "google-protobuf";
 import { grpc } from "clarifai-nodejs-grpc";

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -3,7 +3,8 @@ import { ClarifaiAuthHelper } from "./auth/helper";
 import { getFromDictOrEnv } from "../utils/misc";
 import { createStub } from "./auth/stub";
 import { V2Stub } from "./auth/register";
-import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb.js";
+import timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb.js";
+const { Timestamp } = timestamp_pb;
 import { AuthConfig } from "../utils/types";
 import * as jspb from "google-protobuf";
 import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
@@ -96,7 +97,7 @@ export class BaseClient {
    * @param dateStr The string to convert.
    * @returns A Timestamp object representing the given date string.
    */
-  convertStringToTimestamp(dateStr: string): Timestamp {
+  convertStringToTimestamp(dateStr: string): timestamp_pb.Timestamp {
     const timestamp = new Timestamp();
 
     // Attempt to parse the date string into a Date object

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -1,4 +1,4 @@
-import { UserAppIDSet } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import { ClarifaiAuthHelper } from "./auth/helper";
 import { getFromDictOrEnv } from "../utils/misc";
 import { createStub } from "./auth/stub";
@@ -6,8 +6,8 @@ import { V2Stub } from "./auth/register";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb.js";
 import { AuthConfig } from "../utils/types";
 import * as jspb from "google-protobuf";
-import { grpc } from "clarifai-nodejs-grpc";
-import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
+import status_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
 
 /**
  * BaseClient is the base class for all the classes interacting with Clarifai endpoints.
@@ -18,7 +18,7 @@ import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb
  * @property {V2Stub} STUB The gRPC Stub object for API interaction.
  * @property {[string, string][]} metadata The gRPC metadata containing the personal access token.
  * @property {string} pat The personal access token.
- * @property {UserAppIDSet} userAppId The protobuf object representing user and app IDs.
+ * @property {resources_pb.UserAppIDSet} userAppId The protobuf object representing user and app IDs.
  * @property {string} base The base URL for the API endpoint.
  */
 export class BaseClient {
@@ -26,7 +26,7 @@ export class BaseClient {
   protected STUB: V2Stub;
   protected metadata: [string, string][];
   protected pat: string;
-  protected userAppId: UserAppIDSet;
+  protected userAppId: resources_pb.UserAppIDSet;
   protected base: string;
   protected rootCertificatesPath: string;
 
@@ -75,15 +75,15 @@ export class BaseClient {
    */
   protected async grpcRequest<
     TRequest extends jspb.Message,
-    TResponseObject extends { status?: Status.AsObject },
+    TResponseObject extends { status?: status_pb.Status.AsObject },
     TResponse extends {
       toObject: (arg?: boolean) => TResponseObject;
     },
   >(
     endpoint: (
       request: TRequest,
-      metadata: grpc.Metadata,
-      options: Partial<grpc.CallOptions>,
+      metadata: clarifai_nodejs_grpc.grpc.Metadata,
+      options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
     ) => Promise<TResponse>,
     requestData: TRequest,
   ): Promise<TResponse> {

--- a/src/client/dataset.ts
+++ b/src/client/dataset.ts
@@ -18,7 +18,8 @@ import {
   Struct,
 } from "google-protobuf/google/protobuf/struct_pb.js";
 import { promisifyGrpcCall } from "../utils/misc";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
 
 type DatasetConfig =
   | {

--- a/src/client/dataset.ts
+++ b/src/client/dataset.ts
@@ -11,10 +11,8 @@ const {
   ListDatasetVersionsRequest,
   PostDatasetVersionsRequest,
 } = service_pb;
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 import { promisifyGrpcCall } from "../utils/misc";
 import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
 const { StatusCode } = status_code_pb;
@@ -64,7 +62,7 @@ export class Dataset extends Lister {
   }: {
     id: string;
     description: string;
-    metadata?: Record<string, JavaScriptValue>;
+    metadata?: Record<string, struct_pb.JavaScriptValue>;
   }): Promise<resources_pb.DatasetVersion.AsObject> {
     const request = new PostDatasetVersionsRequest();
     request.setUserAppId(this.userAppId);

--- a/src/client/dataset.ts
+++ b/src/client/dataset.ts
@@ -16,7 +16,7 @@ import {
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { promisifyGrpcCall } from "../utils/misc";
 import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
 

--- a/src/client/dataset.ts
+++ b/src/client/dataset.ts
@@ -1,18 +1,16 @@
-import {
-  DatasetVersion,
-  Dataset as GrpcDataset,
-  Input as GrpcInput,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const { DatasetVersion, Dataset: GrpcDataset } = resources_pb;
 import { UserError } from "../errors";
 import { ClarifaiUrl, ClarifaiUrlHelper } from "../urls/helper";
 import { AuthConfig } from "../utils/types";
 import { Lister } from "./lister";
 import { Input, InputBulkUpload } from "./input";
-import {
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+const {
   DeleteDatasetVersionsRequest,
   ListDatasetVersionsRequest,
   PostDatasetVersionsRequest,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+} = service_pb;
 import {
   JavaScriptValue,
   Struct,
@@ -36,7 +34,7 @@ type DatasetConfig =
     };
 
 export class Dataset extends Lister {
-  private info: GrpcDataset = new GrpcDataset();
+  private info: resources_pb.Dataset = new GrpcDataset();
   private batchSize: number = 128;
   private input: Input;
 
@@ -67,7 +65,7 @@ export class Dataset extends Lister {
     id: string;
     description: string;
     metadata?: Record<string, JavaScriptValue>;
-  }): Promise<DatasetVersion.AsObject> {
+  }): Promise<resources_pb.DatasetVersion.AsObject> {
     const request = new PostDatasetVersionsRequest();
     request.setUserAppId(this.userAppId);
     request.setDatasetId(this.info.getId());
@@ -113,7 +111,7 @@ export class Dataset extends Lister {
   async *listVersions(
     pageNo?: number,
     perPage?: number,
-  ): AsyncGenerator<DatasetVersion.AsObject[], void, unknown> {
+  ): AsyncGenerator<resources_pb.DatasetVersion.AsObject[], void, unknown> {
     const request = new ListDatasetVersionsRequest();
     request.setUserAppId(this.userAppId);
     request.setDatasetId(this.info.getId());
@@ -151,7 +149,7 @@ export class Dataset extends Lister {
     if (["image", "text"].indexOf(inputType) === -1) {
       throw new UserError("Invalid input type");
     }
-    let inputProtos: GrpcInput[] = [];
+    let inputProtos: resources_pb.Input[] = [];
     if (inputType === "image") {
       inputProtos = Input.getImageInputsFromFolder({
         folderPath: folderPath,

--- a/src/client/input.ts
+++ b/src/client/input.ts
@@ -22,10 +22,8 @@ import { Buffer } from "buffer";
 import fs from "fs";
 import path from "path";
 import { z } from "zod";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 import { parse } from "csv-parse";
 import { finished } from "stream/promises";
 import { v4 as uuid } from "uuid";
@@ -140,7 +138,7 @@ export class Input extends Lister {
     textPb?: { raw: string } | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): resources_pb.Input {
     const geoInfoSchema = z
       .array(
@@ -249,7 +247,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): resources_pb.Input {
     if (!(imageBytes || videoBytes || audioBytes || textBytes)) {
       throw new Error(
@@ -313,7 +311,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): resources_pb.Input {
     if (!(imageFile || videoFile || audioFile || textFile)) {
       throw new Error(
@@ -377,7 +375,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): resources_pb.Input {
     if (!(imageUrl || videoUrl || audioUrl || textUrl)) {
       throw new Error(
@@ -488,7 +486,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): resources_pb.Input {
     const textPb = rawText ? { raw: rawText } : null;
     return this.getProto({
@@ -863,7 +861,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): Promise<string> {
     const inputPb = Input.getInputFromUrl({
       inputId,
@@ -898,7 +896,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): Promise<string> {
     const inputProto = Input.getInputFromFile({
       inputId,
@@ -933,7 +931,7 @@ export class Input extends Lister {
     datasetId?: string | null;
     geoInfo?: resources_pb.GeoPoint.AsObject | null;
     labels?: string[] | null;
-    metadata?: Record<string, JavaScriptValue> | null;
+    metadata?: Record<string, struct_pb.JavaScriptValue> | null;
   }): Promise<string> {
     const inputProto = Input.getInputFromBytes({
       inputId,

--- a/src/client/input.ts
+++ b/src/client/input.ts
@@ -24,7 +24,7 @@ import { z } from "zod";
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { parse } from "csv-parse";
 import { finished } from "stream/promises";
 import { v4 as uuid } from "uuid";
@@ -40,7 +40,7 @@ import {
 import { BackoffIterator, promisifyGrpcCall } from "../utils/misc";
 import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
 import os from "os";
-import chunk from "lodash/chunk";
+import chunk from "lodash/chunk.js";
 import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
 import async from "async";
 import { MAX_RETRIES } from "../constants/dataset";

--- a/src/client/lister.ts
+++ b/src/client/lister.ts
@@ -1,9 +1,10 @@
-import { grpc } from "clarifai-nodejs-grpc";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
 import * as jspb from "google-protobuf";
 import { AuthConfig } from "../utils/types";
 import { BaseClient } from "./base";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
-import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
+import status_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
 
 export class Lister extends BaseClient {
   defaultPageSize: number;
@@ -21,15 +22,15 @@ export class Lister extends BaseClient {
 
   async *listPagesGenerator<
     TRequest extends jspb.Message,
-    TResponseObject extends { status?: Status.AsObject },
+    TResponseObject extends { status?: status_pb.Status.AsObject },
     TResponse extends {
       toObject: (arg?: boolean) => TResponseObject;
     },
   >(
     endpoint: (
       request: TRequest,
-      metadata: grpc.Metadata,
-      options: Partial<grpc.CallOptions>,
+      metadata: clarifai_nodejs_grpc.grpc.Metadata,
+      options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
     ) => Promise<TResponse>,
     requestData: TRequest,
     pageNo: number = 1,
@@ -85,15 +86,15 @@ export class Lister extends BaseClient {
 
   async listPagesData<
     TRequest extends jspb.Message,
-    TResponseObject extends { status?: Status.AsObject },
+    TResponseObject extends { status?: status_pb.Status.AsObject },
     TResponse extends {
       toObject: (arg?: boolean) => TResponseObject;
     },
   >(
     endpoint: (
       request: TRequest,
-      metadata: grpc.Metadata,
-      options: Partial<grpc.CallOptions>,
+      metadata: clarifai_nodejs_grpc.grpc.Metadata,
+      options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
     ) => Promise<TResponse>,
     requestData: TRequest,
     pageNo: number = 1,

--- a/src/client/model.ts
+++ b/src/client/model.ts
@@ -36,10 +36,8 @@ import {
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { Input } from "./input";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
 const { grpc } = clarifai_nodejs_grpc;
 import { constructPartsFromParams } from "../utils/setPartsFromParams";
@@ -72,7 +70,7 @@ type ModelConfig = ModelConfigWithUrl | ModelConfigWithModelId;
 
 interface GeneralModelPredictConfig {
   inputs: resources_pb.Input[];
-  inferenceParams?: Record<string, JavaScriptValue>;
+  inferenceParams?: Record<string, struct_pb.JavaScriptValue>;
   outputConfig?: resources_pb.OutputConfig;
 }
 
@@ -645,12 +643,12 @@ export class Model extends Lister {
     );
 
     const payloadPart = constructPartsFromPayload(
-      payload as Record<string, JavaScriptValue>,
+      payload as Record<string, struct_pb.JavaScriptValue>,
       targetMethodSignature.inputFieldsList.filter((each) => !each.isParam),
     );
 
     const paramsPart = constructPartsFromParams(
-      params as Record<string, JavaScriptValue>,
+      params as Record<string, struct_pb.JavaScriptValue>,
       targetMethodSignature.inputFieldsList.filter((each) => each.isParam),
     );
 
@@ -1105,7 +1103,7 @@ export class Model extends Lister {
   }: {
     url: string;
     inputType: "image" | "text" | "video" | "audio";
-    inferenceParams?: Record<string, JavaScriptValue>;
+    inferenceParams?: Record<string, struct_pb.JavaScriptValue>;
     outputConfig?: resources_pb.OutputConfig;
   }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     let inputProto: resources_pb.Input;
@@ -1147,7 +1145,7 @@ export class Model extends Lister {
   }: {
     filepath: string;
     inputType: "image" | "text" | "video" | "audio";
-    inferenceParams?: Record<string, JavaScriptValue>;
+    inferenceParams?: Record<string, struct_pb.JavaScriptValue>;
     outputConfig?: resources_pb.OutputConfig;
   }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     if (!fs.existsSync(filepath)) {
@@ -1181,7 +1179,7 @@ export class Model extends Lister {
   }: {
     inputBytes: Buffer;
     inputType: "image" | "text" | "video" | "audio";
-    inferenceParams?: Record<string, JavaScriptValue>;
+    inferenceParams?: Record<string, struct_pb.JavaScriptValue>;
     outputConfig?: resources_pb.OutputConfig;
   }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     if (!(inputBytes instanceof Buffer)) {
@@ -1236,7 +1234,7 @@ export class Model extends Lister {
     inferenceParams,
     outputConfig,
   }: {
-    inferenceParams?: Record<string, JavaScriptValue>;
+    inferenceParams?: Record<string, struct_pb.JavaScriptValue>;
     outputConfig?: resources_pb.OutputConfig;
   }): void {
     let currentModelVersion = this.modelInfo.getModelVersion();

--- a/src/client/model.ts
+++ b/src/client/model.ts
@@ -41,7 +41,7 @@ import { Input } from "./input";
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { grpc } from "clarifai-nodejs-grpc";
 import { constructPartsFromParams } from "../utils/setPartsFromParams";
 import { validateMethodSignaturesList } from "../utils/validateMethodSignaturesList";

--- a/src/client/model.ts
+++ b/src/client/model.ts
@@ -1,30 +1,28 @@
-import {
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+const {
   DeleteModelVersionRequest,
   GetModelRequest,
   ListModelTypesRequest,
   ListModelVersionsRequest,
-  MultiModelVersionResponse,
-  MultiOutputResponse,
   PostModelOutputsRequest,
   PostModelVersionsRequest,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+} = service_pb;
 import { UserError } from "../errors";
 import { ClarifaiUrl, ClarifaiUrlHelper } from "../urls/helper";
 import { BackoffIterator, promisifyGrpcCall } from "../utils/misc";
 import { AuthConfig } from "../utils/types";
 import { Lister } from "./lister";
-import {
-  Model as GrpcModel,
-  Input as GrpcInput,
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const {
+  Model: GrpcModel,
+  Input: GrpcInput,
   ModelVersion,
-  OutputConfig,
   OutputInfo,
   UserAppIDSet,
   Data,
-  MethodSignature,
-  Output,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+} = resources_pb;
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
 import {
   MAX_MODEL_PREDICT_INPUTS,
   TRAINABLE_MODEL_TYPES,
@@ -42,7 +40,8 @@ import {
   JavaScriptValue,
   Struct,
 } from "google-protobuf/google/protobuf/struct_pb.js";
-import { grpc } from "clarifai-nodejs-grpc";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
+const { grpc } = clarifai_nodejs_grpc;
 import { constructPartsFromParams } from "../utils/setPartsFromParams";
 import { validateMethodSignaturesList } from "../utils/validateMethodSignaturesList";
 import { extractPayloadAndParams } from "../utils/extractPayloadAndParams";
@@ -72,9 +71,9 @@ interface ModelConfigWithModelId extends BaseModelConfig {
 type ModelConfig = ModelConfigWithUrl | ModelConfigWithModelId;
 
 interface GeneralModelPredictConfig {
-  inputs: GrpcInput[];
+  inputs: resources_pb.Input[];
   inferenceParams?: Record<string, JavaScriptValue>;
-  outputConfig?: OutputConfig;
+  outputConfig?: resources_pb.OutputConfig;
 }
 
 type TextModelPredictConfig = {
@@ -107,9 +106,9 @@ const isModelConfigWithUrl = (
 export class Model extends Lister {
   private appId: string;
   private id: string;
-  private modelUserAppId: UserAppIDSet | undefined;
+  private modelUserAppId: resources_pb.UserAppIDSet | undefined;
   private modelVersion: { id: string } | undefined;
-  public modelInfo: GrpcModel;
+  public modelInfo: resources_pb.Model;
   private trainingParams: Record<string, unknown>;
 
   /**
@@ -490,8 +489,8 @@ export class Model extends Lister {
    * @includeExample examples/model/createVersion.ts
    */
   async createVersion(
-    modelVersion: ModelVersion,
-  ): Promise<GrpcModel.AsObject | undefined> {
+    modelVersion: resources_pb.ModelVersion,
+  ): Promise<resources_pb.Model.AsObject | undefined> {
     if (this.modelInfo.getModelTypeId() in TRAINABLE_MODEL_TYPES) {
       throw new UserError(
         `${this.modelInfo.getModelTypeId()} is a trainable model type. Use 'model.train()' to train the model`,
@@ -538,7 +537,7 @@ export class Model extends Lister {
     pageNo?: number;
     perPage?: number;
   } = {}): AsyncGenerator<
-    MultiModelVersionResponse.AsObject["modelVersionsList"],
+    service_pb.MultiModelVersionResponse.AsObject["modelVersionsList"],
     void,
     void
   > {
@@ -567,7 +566,7 @@ export class Model extends Lister {
     }
   }
 
-  async methodSignatures(): Promise<MethodSignature.AsObject[]> {
+  async methodSignatures(): Promise<resources_pb.MethodSignature.AsObject[]> {
     if (!this.modelInfo.toObject().modelVersion?.methodSignaturesList)
       await this.loadInfo();
 
@@ -584,8 +583,8 @@ export class Model extends Lister {
   }
 
   static getOutputDataFromModelResponse(
-    outputs: Output.AsObject[],
-  ): Data.AsObject | undefined {
+    outputs: resources_pb.Output.AsObject[],
+  ): resources_pb.Data.AsObject | undefined {
     return outputs?.[0]?.data?.partsList?.[0]?.data;
   }
 
@@ -606,9 +605,9 @@ export class Model extends Lister {
   }
 
   private async constructRequestWithMethodSignature(
-    request: PostModelOutputsRequest,
+    request: service_pb.PostModelOutputsRequest,
     config: TextModelPredictConfig,
-  ): Promise<PostModelOutputsRequest> {
+  ): Promise<service_pb.PostModelOutputsRequest> {
     if (!this.modelInfo.toObject().modelVersion?.methodSignaturesList)
       await this.loadInfo();
 
@@ -684,7 +683,7 @@ export class Model extends Lister {
    */
   async predict(
     predictArgs: TextModelPredictConfig,
-  ): Promise<MultiOutputResponse.AsObject["outputsList"]>;
+  ): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]>;
   /**
    * Predicts the model based on the given inputs.
    * Use the `Input` module to create the input objects.
@@ -705,11 +704,11 @@ export class Model extends Lister {
     inferenceParams,
     outputConfig,
   }: GeneralModelPredictConfig): Promise<
-    MultiOutputResponse.AsObject["outputsList"]
+    service_pb.MultiOutputResponse.AsObject["outputsList"]
   >;
   async predict(
     config: ModelPredictConfig,
-  ): Promise<MultiOutputResponse.AsObject["outputsList"]> {
+  ): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     let request = new PostModelOutputsRequest();
     if (isTextModelPredictConfig(config)) {
       request = await this.constructRequestWithMethodSignature(request, config);
@@ -725,7 +724,7 @@ export class Model extends Lister {
       }
 
       this.overrideModelVersion({ inferenceParams, outputConfig });
-      const requestInputs: GrpcInput[] = [];
+      const requestInputs: resources_pb.Input[] = [];
       for (const input of inputs) {
         requestInputs.push(input);
       }
@@ -743,7 +742,7 @@ export class Model extends Lister {
     }
     const startTime = Date.now();
     const backoffIterator = new BackoffIterator();
-    return new Promise<MultiOutputResponse.AsObject["outputsList"]>(
+    return new Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]>(
       (resolve, reject) => {
         const makeRequest = () => {
           const postModelOutputs = promisifyGrpcCall(
@@ -786,7 +785,8 @@ export class Model extends Lister {
     methodName,
     ...otherParams
   }: TextModelPredictConfig): AsyncGenerator<
-    MultiOutputResponse.AsObject | ["deploying", MultiOutputResponse.AsObject]
+    | service_pb.MultiOutputResponse.AsObject
+    | ["deploying", service_pb.MultiOutputResponse.AsObject]
   > {
     const request = await this.constructRequestWithMethodSignature(
       new PostModelOutputsRequest(),
@@ -805,15 +805,16 @@ export class Model extends Lister {
     const response = this.STUB.client.generateModelOutputs(request, metadata);
 
     const queue: (
-      | MultiOutputResponse.AsObject
-      | ["deploying", MultiOutputResponse.AsObject]
+      | service_pb.MultiOutputResponse.AsObject
+      | ["deploying", service_pb.MultiOutputResponse.AsObject]
     )[] = [];
     let done = false;
     let error: Error | null = null;
     let resolveNext: (() => void) | null = null;
 
     response.on("data", (data) => {
-      const dataObject = data.toObject() as MultiOutputResponse.AsObject;
+      const dataObject =
+        data.toObject() as service_pb.MultiOutputResponse.AsObject;
       if (
         dataObject.status?.code === StatusCode.MODEL_DEPLOYING ||
         dataObject.status?.code === StatusCode.MODEL_BUSY_PLEASE_RETRY ||
@@ -861,15 +862,16 @@ export class Model extends Lister {
     methodName,
     ...otherParams
   }: TextModelPredictConfig): {
-    send: (request: PostModelOutputsRequest) => void;
+    send: (request: service_pb.PostModelOutputsRequest) => void;
     end: () => void;
     iterator: AsyncGenerator<
-      MultiOutputResponse.AsObject | ["deploying", MultiOutputResponse.AsObject]
+      | service_pb.MultiOutputResponse.AsObject
+      | ["deploying", service_pb.MultiOutputResponse.AsObject]
     >;
   } {
     const queue: (
-      | MultiOutputResponse.AsObject
-      | ["deploying", MultiOutputResponse.AsObject]
+      | service_pb.MultiOutputResponse.AsObject
+      | ["deploying", service_pb.MultiOutputResponse.AsObject]
     )[] = [];
     let done = false;
     let error: Error | null = null;
@@ -885,7 +887,8 @@ export class Model extends Lister {
 
     // Handle incoming messages
     duplexConnection.on("data", (data) => {
-      const dataObject = data.toObject() as MultiOutputResponse.AsObject;
+      const dataObject =
+        data.toObject() as service_pb.MultiOutputResponse.AsObject;
       if (
         dataObject.status?.code === StatusCode.MODEL_DEPLOYING ||
         dataObject.status?.code === StatusCode.MODEL_BUSY_PLEASE_RETRY ||
@@ -941,7 +944,7 @@ export class Model extends Lister {
     })();
 
     return {
-      send: (req: PostModelOutputsRequest) => {
+      send: (req: service_pb.PostModelOutputsRequest) => {
         duplexConnection.write(req);
       },
       end: () => {
@@ -953,18 +956,21 @@ export class Model extends Lister {
 
   // @ts-expect-error - this method will be used in the future
   private async stream(config: TextModelPredictConfig): Promise<{
-    send: (request: PostModelOutputsRequest) => void;
+    send: (request: service_pb.PostModelOutputsRequest) => void;
     end: () => void;
-    iterator: AsyncGenerator<MultiOutputResponse.AsObject["outputsList"]>;
+    iterator: AsyncGenerator<
+      service_pb.MultiOutputResponse.AsObject["outputsList"]
+    >;
   }> {
     const startTime = Date.now();
     const timeoutMs = 10 * 60 * 1000;
     const backoff = new BackoffIterator();
 
-    let send!: (req: PostModelOutputsRequest) => void;
+    let send!: (req: service_pb.PostModelOutputsRequest) => void;
     let end!: () => void;
     let streamIterator!: AsyncGenerator<
-      MultiOutputResponse.AsObject | ["deploying", MultiOutputResponse.AsObject]
+      | service_pb.MultiOutputResponse.AsObject
+      | ["deploying", service_pb.MultiOutputResponse.AsObject]
     >;
 
     while (Date.now() - startTime < timeoutMs) {
@@ -1036,7 +1042,7 @@ export class Model extends Lister {
     methodName,
     ...otherParams
   }: TextModelPredictConfig): AsyncGenerator<
-    MultiOutputResponse.AsObject["outputsList"]
+    service_pb.MultiOutputResponse.AsObject["outputsList"]
   > {
     const startTime = Date.now();
     const backoffIterator = new BackoffIterator();
@@ -1100,9 +1106,9 @@ export class Model extends Lister {
     url: string;
     inputType: "image" | "text" | "video" | "audio";
     inferenceParams?: Record<string, JavaScriptValue>;
-    outputConfig?: OutputConfig;
-  }): Promise<MultiOutputResponse.AsObject["outputsList"]> {
-    let inputProto: GrpcInput;
+    outputConfig?: resources_pb.OutputConfig;
+  }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
+    let inputProto: resources_pb.Input;
     if (inputType === "image") {
       inputProto = Input.getInputFromUrl({ inputId: "", imageUrl: url });
     } else if (inputType === "text") {
@@ -1142,8 +1148,8 @@ export class Model extends Lister {
     filepath: string;
     inputType: "image" | "text" | "video" | "audio";
     inferenceParams?: Record<string, JavaScriptValue>;
-    outputConfig?: OutputConfig;
-  }): Promise<MultiOutputResponse.AsObject["outputsList"]> {
+    outputConfig?: resources_pb.OutputConfig;
+  }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     if (!fs.existsSync(filepath)) {
       throw new Error("Invalid filepath.");
     }
@@ -1176,13 +1182,13 @@ export class Model extends Lister {
     inputBytes: Buffer;
     inputType: "image" | "text" | "video" | "audio";
     inferenceParams?: Record<string, JavaScriptValue>;
-    outputConfig?: OutputConfig;
-  }): Promise<MultiOutputResponse.AsObject["outputsList"]> {
+    outputConfig?: resources_pb.OutputConfig;
+  }): Promise<service_pb.MultiOutputResponse.AsObject["outputsList"]> {
     if (!(inputBytes instanceof Buffer)) {
       throw new Error("Invalid bytes.");
     }
 
-    let inputProto: GrpcInput;
+    let inputProto: resources_pb.Input;
     if (inputType === "image") {
       inputProto = Input.getInputFromBytes({
         inputId: "",
@@ -1231,7 +1237,7 @@ export class Model extends Lister {
     outputConfig,
   }: {
     inferenceParams?: Record<string, JavaScriptValue>;
-    outputConfig?: OutputConfig;
+    outputConfig?: resources_pb.OutputConfig;
   }): void {
     let currentModelVersion = this.modelInfo.getModelVersion();
     if (!currentModelVersion) {

--- a/src/client/rag.ts
+++ b/src/client/rag.ts
@@ -13,10 +13,8 @@ import { MAX_UPLOAD_BATCH_SIZE } from "../constants/rag";
 import { UserError } from "../errors";
 import { AuthConfig } from "../utils/types";
 import { ClarifaiAppUrl, ClarifaiUrl, ClarifaiUrlHelper } from "../urls/helper";
-import {
-  ModelVersion,
-  OutputInfo,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const { ModelVersion, OutputInfo } = resources_pb;
 import { validateWorkflow } from "../workflows/validate";
 import {
   Message,

--- a/src/client/rag.ts
+++ b/src/client/rag.ts
@@ -6,7 +6,7 @@ import yaml from "js-yaml";
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { Model } from "./model";
 import { User } from "./user";
 import { MAX_UPLOAD_BATCH_SIZE } from "../constants/rag";
@@ -26,7 +26,7 @@ import {
   splitDocument,
 } from "../rag/utils";
 import { Input } from "./input";
-import compact from "lodash/compact";
+import compact from "lodash/compact.js";
 
 const DEFAULT_RAG_PROMPT_TEMPLATE =
   "Context information is below:\n{data.hits}\nGiven the context information and not prior knowledge, answer the query.\nQuery: {data.text.raw}\nAnswer: ";

--- a/src/client/rag.ts
+++ b/src/client/rag.ts
@@ -3,10 +3,8 @@ import { App, AuthAppConfig } from "./app";
 import { Workflow } from "./workflow";
 import * as fs from "fs";
 import yaml from "js-yaml";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 import { Model } from "./model";
 import { User } from "./user";
 import { MAX_UPLOAD_BATCH_SIZE } from "../constants/rag";
@@ -299,7 +297,7 @@ export class RAG {
     chunkSize?: number;
     chunkOverlap?: number;
     datasetId?: string;
-    metadata?: Record<string, JavaScriptValue>;
+    metadata?: Record<string, struct_pb.JavaScriptValue>;
   }): Promise<void> {
     if (batchSize > MAX_UPLOAD_BATCH_SIZE) {
       throw new UserError(
@@ -324,7 +322,7 @@ export class RAG {
     });
 
     const textChunks: string[] = [];
-    const metadataList: Array<Record<string, JavaScriptValue>> = [];
+    const metadataList: Array<Record<string, struct_pb.JavaScriptValue>> = [];
     let docI = 0;
 
     for (const doc of documents) {

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -27,10 +27,8 @@ import { Input } from "./input";
 import { UserError } from "../errors";
 import { getSchema } from "../schema/search";
 import { z } from "zod";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 import { promisifyGrpcCall } from "../utils/misc";
 import status_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
 const { Status } = status_pb;
@@ -142,7 +140,7 @@ export class Search extends Lister {
         this.dataProto.setText(textProto);
       } else if (key === "metadata") {
         const metadataStruct = Struct.fromJavaScript(
-          value as Record<string, JavaScriptValue>,
+          value as Record<string, struct_pb.JavaScriptValue>,
         );
         this.dataProto.setMetadata(metadataStruct);
       } else if (key === "geoPoint") {

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -29,7 +29,7 @@ import { z } from "zod";
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { promisifyGrpcCall } from "../utils/misc";
 import { Status } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_pb";
 import { grpc } from "clarifai-nodejs-grpc";

--- a/src/client/user.ts
+++ b/src/client/user.ts
@@ -1,19 +1,16 @@
 import { Lister } from "./lister";
 import { AuthConfig, PaginationRequestParams } from "../utils/types";
-import {
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+const {
   DeleteAppRequest,
   DeleteRunnersRequest,
   GetAppRequest,
   GetRunnerRequest,
   ListAppsRequest,
   ListRunnersRequest,
-  MultiAppResponse,
-  MultiRunnerResponse,
   PostAppsRequest,
   PostRunnersRequest,
-  SingleAppResponse,
-  SingleRunnerResponse,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+} = service_pb;
 import { promisifyGrpcCall } from "../utils/misc";
 import {
   App,
@@ -26,9 +23,9 @@ import { fromPartialProtobufObject } from "../utils/fromPartialProtobufObject";
 
 export type UserConfig = AuthConfig;
 export type ListAppsRequestParams =
-  PaginationRequestParams<ListAppsRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListAppsRequest.AsObject>;
 export type ListRunnersRequestParams =
-  PaginationRequestParams<ListRunnersRequest.AsObject>;
+  PaginationRequestParams<service_pb.ListRunnersRequest.AsObject>;
 
 /**
  * User is a class that provides access to Clarifai API endpoints related to user information.
@@ -74,7 +71,7 @@ export class User extends Lister {
     pageNo?: number;
     perPage?: number;
   } = {}): AsyncGenerator<
-    MultiAppResponse.AsObject["appsList"],
+    service_pb.MultiAppResponse.AsObject["appsList"],
     void,
     unknown
   > {
@@ -114,7 +111,11 @@ export class User extends Lister {
     params?: ListRunnersRequestParams;
     pageNo?: number;
     perPage?: number;
-  } = {}): AsyncGenerator<MultiRunnerResponse.AsObject, void, unknown> {
+  } = {}): AsyncGenerator<
+    service_pb.MultiRunnerResponse.AsObject,
+    void,
+    unknown
+  > {
     const listRunners = promisifyGrpcCall(
       this.STUB.client.listRunners,
       this.STUB.client,
@@ -196,7 +197,7 @@ export class User extends Lister {
     runnerId: string;
     labels: string[];
     description: string;
-  }): Promise<MultiRunnerResponse.AsObject["runnersList"][0]> {
+  }): Promise<service_pb.MultiRunnerResponse.AsObject["runnersList"][0]> {
     if (!Array.isArray(labels)) {
       throw new Error("Labels must be an array of strings");
     }
@@ -237,7 +238,7 @@ export class User extends Lister {
     appId,
   }: {
     appId: string;
-  }): Promise<SingleAppResponse.AsObject["app"]> {
+  }): Promise<service_pb.SingleAppResponse.AsObject["app"]> {
     const request = new GetAppRequest();
     const appIdSet = new UserAppIDSet();
     appIdSet.setUserId(this.userAppId.getUserId());
@@ -266,7 +267,7 @@ export class User extends Lister {
     runnerId,
   }: {
     runnerId: string;
-  }): Promise<SingleRunnerResponse.AsObject["runner"]> {
+  }): Promise<service_pb.SingleRunnerResponse.AsObject["runner"]> {
     const request = new GetRunnerRequest();
     request.setUserAppId(this.userAppId);
     request.setRunnerId(runnerId);

--- a/src/client/user.ts
+++ b/src/client/user.ts
@@ -12,13 +12,10 @@ const {
   PostRunnersRequest,
 } = service_pb;
 import { promisifyGrpcCall } from "../utils/misc";
-import {
-  App,
-  Runner,
-  UserAppIDSet,
-  Workflow,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const { App, Runner, UserAppIDSet, Workflow } = resources_pb;
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
 import { fromPartialProtobufObject } from "../utils/fromPartialProtobufObject";
 
 export type UserConfig = AuthConfig;
@@ -147,7 +144,7 @@ export class User extends Lister {
   }: {
     appId: string;
     baseWorkflow?: string;
-  }): Promise<App.AsObject> {
+  }): Promise<resources_pb.App.AsObject> {
     const workflow = new Workflow();
     workflow.setId(baseWorkflow);
     workflow.setAppId("main");

--- a/src/client/workflow.ts
+++ b/src/client/workflow.ts
@@ -2,21 +2,22 @@ import { AuthConfig } from "../utils/types";
 import { Lister } from "./lister";
 import { UserError } from "../errors";
 import { ClarifaiUrl, ClarifaiUrlHelper } from "../urls/helper";
-import {
-  Input as GrpcInput,
-  OutputConfig as GrpcOutputConfig,
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const {
+  Input: GrpcInput,
+  OutputConfig: GrpcOutputConfig,
   WorkflowState,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+} = resources_pb;
 import { MAX_WORKFLOW_PREDICT_INPUTS } from "../constants/workflow";
-import {
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+const {
   GetWorkflowRequest,
   ListWorkflowVersionsRequest,
-  MultiWorkflowVersionResponse,
   PostWorkflowResultsRequest,
-  PostWorkflowResultsResponse,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+} = service_pb;
 import { BackoffIterator, promisifyGrpcCall } from "../utils/misc";
-import { StatusCode } from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+import status_code_pb from "clarifai-nodejs-grpc/proto/clarifai/api/status/status_code_pb";
+const { StatusCode } = status_code_pb;
 import { Input } from "./input";
 import { Exporter } from "../workflows/export";
 import { fromPartialProtobufObject } from "../utils/fromPartialProtobufObject";
@@ -84,9 +85,9 @@ export class Workflow extends Lister {
     inputs,
     workflowStateId,
   }: {
-    inputs: GrpcInput[];
-    workflowStateId?: WorkflowState.AsObject["id"];
-  }): Promise<PostWorkflowResultsResponse.AsObject> {
+    inputs: resources_pb.Input[];
+    workflowStateId?: resources_pb.WorkflowState.AsObject["id"];
+  }): Promise<service_pb.PostWorkflowResultsResponse.AsObject> {
     if (inputs.length > MAX_WORKFLOW_PREDICT_INPUTS) {
       throw new UserError(
         `Too many inputs. Max is ${MAX_WORKFLOW_PREDICT_INPUTS}.`,
@@ -154,7 +155,7 @@ export class Workflow extends Lister {
   predictByBytes(
     inputBytes: Buffer,
     inputType: "image" | "text" | "video" | "audio",
-  ): Promise<PostWorkflowResultsResponse.AsObject> {
+  ): Promise<service_pb.PostWorkflowResultsResponse.AsObject> {
     if (!["image", "text", "video", "audio"].includes(inputType)) {
       throw new UserError(
         "Invalid input type. It should be image, text, video, or audio.",
@@ -193,7 +194,7 @@ export class Workflow extends Lister {
   predictByUrl(
     url: string,
     inputType: "image" | "text" | "video" | "audio",
-  ): Promise<PostWorkflowResultsResponse.AsObject> {
+  ): Promise<service_pb.PostWorkflowResultsResponse.AsObject> {
     if (!["image", "text", "video", "audio"].includes(inputType)) {
       throw new UserError(
         "Invalid input type. It should be image, text, video, or audio.",
@@ -218,7 +219,11 @@ export class Workflow extends Lister {
   }: {
     pageNo?: number;
     perPage?: number;
-  }): AsyncGenerator<MultiWorkflowVersionResponse.AsObject, void, void> {
+  }): AsyncGenerator<
+    service_pb.MultiWorkflowVersionResponse.AsObject,
+    void,
+    void
+  > {
     const request = new ListWorkflowVersionsRequest();
     request.setUserAppId(this.userAppId);
     request.setWorkflowId(this.id);

--- a/src/datasets/upload/base.ts
+++ b/src/datasets/upload/base.ts
@@ -1,7 +1,4 @@
-import {
-  Annotation,
-  Input,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import {
   TextFeatures,
   VisualClassificationFeatures,
@@ -47,7 +44,7 @@ export abstract class ClarifaiDataset<T extends ClarifaiDataLoader> {
 
   protected abstract extractProtos(_args: {
     batchInputIds: string[];
-  }): [Input[], Annotation[]];
+  }): [resources_pb.Input[], resources_pb.Annotation[]];
 
   // TODO: Plan for implementation
   // abstract getProtos(_inputIds: number[]): [Input[], Annotation[]];

--- a/src/datasets/upload/features.ts
+++ b/src/datasets/upload/features.ts
@@ -1,4 +1,4 @@
-import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
 import { Polygon } from "../../utils/types";
 
 export interface TextFeatures {
@@ -8,7 +8,7 @@ export interface TextFeatures {
   text: string;
   labels: Array<string | number>;
   id?: number;
-  metadata?: Record<string, JavaScriptValue>;
+  metadata?: Record<string, struct_pb.JavaScriptValue>;
   bboxes?: undefined;
 }
 
@@ -17,7 +17,7 @@ export interface VisualClassificationFeatures {
   labels: Array<string | number>;
   geoInfo?: [number, number];
   id?: number;
-  metadata?: Record<string, JavaScriptValue>;
+  metadata?: Record<string, struct_pb.JavaScriptValue>;
   imageBytes?: Buffer;
 }
 
@@ -27,7 +27,7 @@ export interface VisualDetectionFeatures {
   bboxes: Array<Array<number>>;
   geoInfo?: [number, number];
   id?: number;
-  metadata?: Record<string, JavaScriptValue>;
+  metadata?: Record<string, struct_pb.JavaScriptValue>;
   imageBytes?: Buffer;
 }
 
@@ -37,6 +37,6 @@ export interface VisualSegmentationFeatures {
   polygons: Polygon[];
   geoInfo?: [number, number];
   id?: number;
-  metadata?: Record<string, JavaScriptValue>;
+  metadata?: Record<string, struct_pb.JavaScriptValue>;
   imageBytes?: Buffer;
 }

--- a/src/datasets/upload/features.ts
+++ b/src/datasets/upload/features.ts
@@ -1,4 +1,4 @@
-import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb";
+import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb.js";
 import { Polygon } from "../../utils/types";
 
 export interface TextFeatures {

--- a/src/datasets/upload/image.ts
+++ b/src/datasets/upload/image.ts
@@ -11,7 +11,7 @@ import {
   VisualDetectionFeatures,
   VisualSegmentationFeatures,
 } from "./features";
-import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb";
+import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb.js";
 
 export class VisualClassificationDataset extends ClarifaiDataset<ClarifaiDataLoader> {
   constructor(args: { dataGenerator: ClarifaiDataLoader; datasetId: string }) {

--- a/src/datasets/upload/image.ts
+++ b/src/datasets/upload/image.ts
@@ -8,7 +8,7 @@ import {
   VisualDetectionFeatures,
   VisualSegmentationFeatures,
 } from "./features";
-import { JavaScriptValue } from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
 
 export class VisualClassificationDataset extends ClarifaiDataset<ClarifaiDataLoader> {
   constructor(args: { dataGenerator: ClarifaiDataLoader; datasetId: string }) {
@@ -27,7 +27,7 @@ export class VisualClassificationDataset extends ClarifaiDataset<ClarifaiDataLoa
       const dataItem = this.dataGenerator.getItem(
         Number(id),
       ) as VisualClassificationFeatures;
-      let metadata: Record<string, JavaScriptValue> = {};
+      let metadata: Record<string, struct_pb.JavaScriptValue> = {};
       const imagePath = dataItem.imagePath;
       const labels = Array.isArray(dataItem.labels)
         ? dataItem.labels.map((label) => label.toString())
@@ -99,7 +99,7 @@ export class VisualDetectionDataset extends ClarifaiDataset<ClarifaiDataLoader> 
       const dataItem = this.dataGenerator.getItem(
         Number(id),
       ) as VisualDetectionFeatures;
-      let metadata: Record<string, JavaScriptValue> = {};
+      let metadata: Record<string, struct_pb.JavaScriptValue> = {};
       const image = dataItem.imagePath;
       const labels = dataItem.labels.map((label) => label.toString());
       const bboxes = dataItem.bboxes;
@@ -179,7 +179,7 @@ export class VisualSegmentationDataset extends ClarifaiDataset<ClarifaiDataLoade
       const dataItem = this.dataGenerator.getItem(
         Number(id),
       ) as VisualSegmentationFeatures;
-      let metadata: Record<string, JavaScriptValue> = {};
+      let metadata: Record<string, struct_pb.JavaScriptValue> = {};
       const image = dataItem.imagePath;
       const labels = dataItem.labels.map((label) => label.toString());
       const polygons = dataItem.polygons;

--- a/src/datasets/upload/image.ts
+++ b/src/datasets/upload/image.ts
@@ -1,7 +1,4 @@
-import {
-  Input as GrpcInput,
-  Annotation,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import { ClarifaiDataLoader, ClarifaiDataset } from "./base";
 import path from "path";
 import { v4 as uuid } from "uuid";
@@ -22,9 +19,9 @@ export class VisualClassificationDataset extends ClarifaiDataset<ClarifaiDataLoa
     batchInputIds,
   }: {
     batchInputIds: string[];
-  }): [GrpcInput[], Annotation[]] {
-    const inputProtos: GrpcInput[] = [];
-    const annotationProtos: Annotation[] = [];
+  }): [resources_pb.Input[], resources_pb.Annotation[]] {
+    const inputProtos: resources_pb.Input[] = [];
+    const annotationProtos: resources_pb.Annotation[] = [];
 
     const processDataItem = (id: string) => {
       const dataItem = this.dataGenerator.getItem(
@@ -94,9 +91,9 @@ export class VisualDetectionDataset extends ClarifaiDataset<ClarifaiDataLoader> 
     batchInputIds,
   }: {
     batchInputIds: string[];
-  }): [GrpcInput[], Annotation[]] {
-    const inputProtos: GrpcInput[] = [];
-    const annotationProtos: Annotation[] = [];
+  }): [resources_pb.Input[], resources_pb.Annotation[]] {
+    const inputProtos: resources_pb.Input[] = [];
+    const annotationProtos: resources_pb.Annotation[] = [];
 
     const processDataItem = (id: string) => {
       const dataItem = this.dataGenerator.getItem(
@@ -174,9 +171,9 @@ export class VisualSegmentationDataset extends ClarifaiDataset<ClarifaiDataLoade
     batchInputIds,
   }: {
     batchInputIds: string[];
-  }): [GrpcInput[], Annotation[]] {
-    const inputProtos: GrpcInput[] = [];
-    const annotationProtos: Annotation[] = [];
+  }): [resources_pb.Input[], resources_pb.Annotation[]] {
+    const inputProtos: resources_pb.Input[] = [];
+    const annotationProtos: resources_pb.Annotation[] = [];
 
     const processDataItem = (id: string) => {
       const dataItem = this.dataGenerator.getItem(

--- a/src/utils/constructPartsFromPayload.ts
+++ b/src/utils/constructPartsFromPayload.ts
@@ -1,8 +1,5 @@
 import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
 import { setPartDataTypes } from "./setPartsFromParams";
 import { fromPartialProtobufObject } from "./fromPartialProtobufObject";
 const {
@@ -16,9 +13,12 @@ const {
   Region,
   Video,
 } = resources_pb;
+const { Struct } = struct_pb;
 
 export const constructPartsFromPayload = (
-  payload: Record<string, JavaScriptValue> | JavaScriptValue[],
+  payload:
+    | Record<string, struct_pb.JavaScriptValue>
+    | struct_pb.JavaScriptValue[],
   modelPayloadSpecs?: resources_pb.ModelTypeField.AsObject[],
 ) => {
   const partsList: resources_pb.Part[] = [];
@@ -67,7 +67,7 @@ export const constructPartsFromPayload = (
 
     if (specs?.typeArgsList?.length) {
       nestedPartsList = constructPartsFromPayload(
-        fieldValue as JavaScriptValue[],
+        fieldValue as struct_pb.JavaScriptValue[],
         specs.typeArgsList,
       );
     }

--- a/src/utils/constructPartsFromPayload.ts
+++ b/src/utils/constructPartsFromPayload.ts
@@ -12,7 +12,7 @@ import {
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 import { setPartDataTypes } from "./setPartsFromParams";
 import { fromPartialProtobufObject } from "./fromPartialProtobufObject";
 

--- a/src/utils/constructPartsFromPayload.ts
+++ b/src/utils/constructPartsFromPayload.ts
@@ -1,4 +1,11 @@
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import {
+  JavaScriptValue,
+  Struct,
+} from "google-protobuf/google/protobuf/struct_pb.js";
+import { setPartDataTypes } from "./setPartsFromParams";
+import { fromPartialProtobufObject } from "./fromPartialProtobufObject";
+const {
   Audio,
   Concept,
   Data,
@@ -8,19 +15,13 @@ import {
   Part,
   Region,
   Video,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
-import { setPartDataTypes } from "./setPartsFromParams";
-import { fromPartialProtobufObject } from "./fromPartialProtobufObject";
+} = resources_pb;
 
 export const constructPartsFromPayload = (
   payload: Record<string, JavaScriptValue> | JavaScriptValue[],
-  modelPayloadSpecs?: ModelTypeField.AsObject[],
+  modelPayloadSpecs?: resources_pb.ModelTypeField.AsObject[],
 ) => {
-  const partsList: Part[] = [];
+  const partsList: resources_pb.Part[] = [];
 
   if (Array.isArray(payload)) {
     payload.forEach((nestedPayload) => {
@@ -62,7 +63,7 @@ export const constructPartsFromPayload = (
     part.setData(data);
     part.setId(fieldName);
 
-    let nestedPartsList: Part[] | undefined = undefined;
+    let nestedPartsList: resources_pb.Part[] | undefined = undefined;
 
     if (specs?.typeArgsList?.length) {
       nestedPartsList = constructPartsFromPayload(

--- a/src/utils/extractPayloadAndParams.ts
+++ b/src/utils/extractPayloadAndParams.ts
@@ -1,8 +1,8 @@
-import { ModelTypeField } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 
 export const extractPayloadAndParams = (
   requestObject: Record<string, unknown>,
-  paramSpecs: ModelTypeField.AsObject[],
+  paramSpecs: resources_pb.ModelTypeField.AsObject[],
 ) => {
   const payload: Record<string, unknown> = {};
   const params: Record<string, unknown> = {};

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,7 +1,7 @@
 import { V2Client } from "clarifai-nodejs-grpc/proto/clarifai/api/service_grpc_pb";
 import { UserError } from "../errors";
 import { GrpcWithCallback, AuthConfig } from "./types";
-import { grpc } from "clarifai-nodejs-grpc";
+import clarifai_nodejs_grpc from "clarifai-nodejs-grpc";
 
 /**
  * Get a value from a dictionary or an environment variable.
@@ -36,13 +36,13 @@ export function promisifyGrpcCall<TRequest, TResponse>(
   client: V2Client,
 ): (
   request: TRequest,
-  metadata: grpc.Metadata,
-  options: Partial<grpc.CallOptions>,
+  metadata: clarifai_nodejs_grpc.grpc.Metadata,
+  options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
 ) => Promise<TResponse> {
   return (
     request: TRequest,
-    metadata: grpc.Metadata,
-    options: Partial<grpc.CallOptions>,
+    metadata: clarifai_nodejs_grpc.grpc.Metadata,
+    options: Partial<clarifai_nodejs_grpc.grpc.CallOptions>,
   ): Promise<TResponse> => {
     return new Promise((resolve, reject) => {
       func.bind(client)(request, metadata, options, (error, response) => {

--- a/src/utils/modelTrain.ts
+++ b/src/utils/modelTrain.ts
@@ -1,11 +1,11 @@
-import { MultiModelTypeResponse } from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
 import { writeFileSync } from "fs";
 
 /**
  * Converts the response from the API to a list of templates for the given model type id.
  */
 export function responseToTemplates(
-  response: MultiModelTypeResponse.AsObject,
+  response: service_pb.MultiModelTypeResponse.AsObject,
   modelTypeId: string,
 ): string[] {
   let templates: string[] = [];
@@ -27,7 +27,7 @@ export function responseToTemplates(
  * Converts the response from the API to a dictionary of model params for the given model type id.
  */
 export function responseToModelParams(
-  response: MultiModelTypeResponse.AsObject,
+  response: service_pb.MultiModelTypeResponse.AsObject,
   modelTypeId: string,
   template: string | null = null,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -130,7 +130,7 @@ export function findAndReplaceKey(
  * Converts the response from the API to a dictionary of model param info for the given model type id.
  */
 export function responseToParamInfo(
-  response: MultiModelTypeResponse.AsObject,
+  response: service_pb.MultiModelTypeResponse.AsObject,
   modelTypeId: string,
   param: string,
   template: string | null = null,

--- a/src/utils/setPartsFromParams.ts
+++ b/src/utils/setPartsFromParams.ts
@@ -1,14 +1,11 @@
 import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 const { Data, Part } = resources_pb;
-import {
-  JavaScriptValue,
-  Struct,
-  Value,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 
 export const setPartDataTypes = (
   data: resources_pb.Data,
-  value: Value.AsObject,
+  value: struct_pb.Value.AsObject,
   fieldType?: number,
 ) => {
   const stringVal = value.stringValue;
@@ -33,7 +30,7 @@ export const setPartDataTypes = (
 };
 
 export const constructPartsFromParams = (
-  params: Record<string, JavaScriptValue>,
+  params: Record<string, struct_pb.JavaScriptValue>,
   modelParamSpecs?: resources_pb.ModelTypeField.AsObject[],
 ) => {
   const paramsStruct = Struct.fromJavaScript(params).toObject();

--- a/src/utils/setPartsFromParams.ts
+++ b/src/utils/setPartsFromParams.ts
@@ -7,7 +7,7 @@ import {
   JavaScriptValue,
   Struct,
   Value,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 
 export const setPartDataTypes = (
   data: Data,

--- a/src/utils/setPartsFromParams.ts
+++ b/src/utils/setPartsFromParams.ts
@@ -1,8 +1,5 @@
-import {
-  Data,
-  ModelTypeField,
-  Part,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const { Data, Part } = resources_pb;
 import {
   JavaScriptValue,
   Struct,
@@ -10,7 +7,7 @@ import {
 } from "google-protobuf/google/protobuf/struct_pb.js";
 
 export const setPartDataTypes = (
-  data: Data,
+  data: resources_pb.Data,
   value: Value.AsObject,
   fieldType?: number,
 ) => {
@@ -37,7 +34,7 @@ export const setPartDataTypes = (
 
 export const constructPartsFromParams = (
   params: Record<string, JavaScriptValue>,
-  modelParamSpecs?: ModelTypeField.AsObject[],
+  modelParamSpecs?: resources_pb.ModelTypeField.AsObject[],
 ) => {
   const paramsStruct = Struct.fromJavaScript(params).toObject();
   const newParts = Object.entries(paramsStruct.fieldsMap).map(

--- a/src/utils/validateMethodSignaturesList.ts
+++ b/src/utils/validateMethodSignaturesList.ts
@@ -1,36 +1,39 @@
-import { ModelTypeField } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import { z } from "zod";
 
-const typeValidators: Record<ModelTypeField.DataType, z.ZodTypeAny> = {
-  [ModelTypeField.DataType.NOT_SET]: z.undefined().or(z.null()),
-  [ModelTypeField.DataType.STR]: z.string(),
-  [ModelTypeField.DataType.BYTES]: z.any(), // placeholder; customize per your bytes format
-  [ModelTypeField.DataType.INT]: z.number().int(),
-  [ModelTypeField.DataType.FLOAT]: z.number().refine((n) => {
+const typeValidators: Record<
+  resources_pb.ModelTypeField.DataType,
+  z.ZodTypeAny
+> = {
+  [resources_pb.ModelTypeField.DataType.NOT_SET]: z.undefined().or(z.null()),
+  [resources_pb.ModelTypeField.DataType.STR]: z.string(),
+  [resources_pb.ModelTypeField.DataType.BYTES]: z.any(), // placeholder; customize per your bytes format
+  [resources_pb.ModelTypeField.DataType.INT]: z.number().int(),
+  [resources_pb.ModelTypeField.DataType.FLOAT]: z.number().refine((n) => {
     // Based on https://github.com/colinhacks/zod/discussions/2237#discussioncomment-5487432
     return (
       !z.number().int().safeParse(n).success &&
       z.number().finite().safeParse(n).success
     );
   }),
-  [ModelTypeField.DataType.BOOL]: z.boolean(),
-  [ModelTypeField.DataType.NDARRAY]: z.any(), // could add stricter shape if using ndarray lib
-  [ModelTypeField.DataType.JSON_DATA]: z.record(z.any()),
-  [ModelTypeField.DataType.TEXT]: z.string(),
-  [ModelTypeField.DataType.IMAGE]: z.any(), // placeholder; customize per your image format
-  [ModelTypeField.DataType.CONCEPT]: z.any(),
-  [ModelTypeField.DataType.REGION]: z.any(),
-  [ModelTypeField.DataType.FRAME]: z.any(),
-  [ModelTypeField.DataType.AUDIO]: z.any(),
-  [ModelTypeField.DataType.VIDEO]: z.any(),
-  [ModelTypeField.DataType.NAMED_FIELDS]: z.record(z.any()),
-  [ModelTypeField.DataType.TUPLE]: z.array(z.any()), // accepts any array
-  [ModelTypeField.DataType.LIST]: z.array(z.any()),
+  [resources_pb.ModelTypeField.DataType.BOOL]: z.boolean(),
+  [resources_pb.ModelTypeField.DataType.NDARRAY]: z.any(), // could add stricter shape if using ndarray lib
+  [resources_pb.ModelTypeField.DataType.JSON_DATA]: z.record(z.any()),
+  [resources_pb.ModelTypeField.DataType.TEXT]: z.string(),
+  [resources_pb.ModelTypeField.DataType.IMAGE]: z.any(), // placeholder; customize per your image format
+  [resources_pb.ModelTypeField.DataType.CONCEPT]: z.any(),
+  [resources_pb.ModelTypeField.DataType.REGION]: z.any(),
+  [resources_pb.ModelTypeField.DataType.FRAME]: z.any(),
+  [resources_pb.ModelTypeField.DataType.AUDIO]: z.any(),
+  [resources_pb.ModelTypeField.DataType.VIDEO]: z.any(),
+  [resources_pb.ModelTypeField.DataType.NAMED_FIELDS]: z.record(z.any()),
+  [resources_pb.ModelTypeField.DataType.TUPLE]: z.array(z.any()), // accepts any array
+  [resources_pb.ModelTypeField.DataType.LIST]: z.array(z.any()),
 };
 
 export const validateMethodSignaturesList = (
   params: Record<string, unknown>,
-  inputFieldsList: ModelTypeField.AsObject[],
+  inputFieldsList: resources_pb.ModelTypeField.AsObject[],
 ) => {
   const requiredFieldsList = inputFieldsList
     .filter((each) => each.required)

--- a/src/workflows/export.ts
+++ b/src/workflows/export.ts
@@ -1,4 +1,4 @@
-import { SingleWorkflowResponse } from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
+import service_pb from "clarifai-nodejs-grpc/proto/clarifai/api/service_pb";
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 
@@ -14,11 +14,11 @@ const VALID_YAML_KEYS = [
 ];
 
 export class Exporter {
-  private wf?: SingleWorkflowResponse.AsObject;
+  private wf?: service_pb.SingleWorkflowResponse.AsObject;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private wf_dict?: Record<string, any>;
 
-  constructor(workflow: SingleWorkflowResponse.AsObject) {
+  constructor(workflow: service_pb.SingleWorkflowResponse.AsObject) {
     this.wf = workflow;
   }
 

--- a/src/workflows/utils.ts
+++ b/src/workflows/utils.ts
@@ -5,7 +5,7 @@ import {
 import {
   JavaScriptValue,
   Struct,
-} from "google-protobuf/google/protobuf/struct_pb";
+} from "google-protobuf/google/protobuf/struct_pb.js";
 
 interface YamlModelOutputInfo {
   params?: Record<string, JavaScriptValue>;

--- a/src/workflows/utils.ts
+++ b/src/workflows/utils.ts
@@ -1,7 +1,5 @@
-import {
-  Model,
-  OutputInfo,
-} from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
+const { OutputInfo } = resources_pb;
 import {
   JavaScriptValue,
   Struct,
@@ -15,7 +13,7 @@ type YamlModel = Record<string, unknown>;
 
 export function getYamlOutputInfoProto(
   yamlModelOutputInfo: YamlModelOutputInfo,
-): OutputInfo | undefined {
+): resources_pb.OutputInfo | undefined {
   if (!yamlModelOutputInfo?.params) {
     return undefined;
   }
@@ -36,7 +34,7 @@ function convertYamlParamsToApiParams(
 }
 
 export function isSameYamlModel(
-  apiModel: Model.AsObject,
+  apiModel: resources_pb.Model.AsObject,
   yamlModel: YamlModel,
 ): boolean {
   const yamlModelFromApi: YamlModel = {};

--- a/src/workflows/utils.ts
+++ b/src/workflows/utils.ts
@@ -1,12 +1,10 @@
 import resources_pb from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 const { OutputInfo } = resources_pb;
-import {
-  JavaScriptValue,
-  Struct,
-} from "google-protobuf/google/protobuf/struct_pb.js";
+import struct_pb from "google-protobuf/google/protobuf/struct_pb.js";
+const { Struct } = struct_pb;
 
 interface YamlModelOutputInfo {
-  params?: Record<string, JavaScriptValue>;
+  params?: Record<string, struct_pb.JavaScriptValue>;
 }
 
 type YamlModel = Record<string, unknown>;
@@ -25,7 +23,7 @@ export function getYamlOutputInfoProto(
 
 function convertYamlParamsToApiParams(
   yamlParams: YamlModelOutputInfo["params"],
-): Struct | undefined {
+): struct_pb.Struct | undefined {
   if (!yamlParams) {
     return undefined;
   }


### PR DESCRIPTION
This PR is a follow up to https://github.com/Clarifai/clarifai-nodejs-grpc/pull/79 

It rewrites all the import statements of packages that doesn't have an ESM version for compatibility with newer node.js versions.