### PR TITLE
fix: minor issue with exporting types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "types": "dist/types.d.ts",
   "exports": {
     "import": "./dist/module.js",
-    "require": "./dist/main.js"
+    "require": "./dist/main.js",
+    "types": "./dist/types.d.ts"
   },
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
This pull request makes a small improvement to the `package.json` file by adding a `types` field to the `exports` object. This change ensures type definitions are explicitly exported for better TypeScript support.