### PR TITLE
chore: updated form-data package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "async": "^3.2.5",
         "axios": "^1.8.2",
         "chalk": "^5.3.0",
-        "clarifai-nodejs-grpc": "^11.4.3",
+        "clarifai-nodejs-grpc": "^11.6.6",
         "csv-parse": "^5.5.5",
         "from-protobuf-object": "^1.0.3",
         "google-protobuf": "^3.21.2",
@@ -6320,9 +6320,9 @@
       }
     },
     "node_modules/clarifai-nodejs-grpc": {
-      "version": "11.4.3",
-      "resolved": "https://registry.npmjs.org/clarifai-nodejs-grpc/-/clarifai-nodejs-grpc-11.4.3.tgz",
-      "integrity": "sha512-BAOzIKv6v+2VYSXpzZERTTnsADWlrTrYfoI52U3jwkMGT4JiXkOUR9Fn4unhU6Y7pGnncUQ0UuYWYUlGNoWAog==",
+      "version": "11.6.6",
+      "resolved": "https://registry.npmjs.org/clarifai-nodejs-grpc/-/clarifai-nodejs-grpc-11.6.6.tgz",
+      "integrity": "sha512-gDgm8LjpN0QmgTw0zRxuGqU7TUw9PFrOQOMDILTMM4aS2ItSPA5llUrkHcxm9nVpplFxzrrDicOwH3SgPQRWcw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.4.2",
         "@grpc/proto-loader": "^0.5.5",
@@ -6779,6 +6779,20 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7369,12 +7383,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -7690,6 +7706,20 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "async": "^3.2.5",
     "axios": "^1.8.2",
     "chalk": "^5.3.0",
-    "clarifai-nodejs-grpc": "^11.4.3",
+    "clarifai-nodejs-grpc": "^11.6.6",
     "csv-parse": "^5.5.5",
     "from-protobuf-object": "^1.0.3",
     "google-protobuf": "^3.21.2",
@@ -84,5 +84,8 @@
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "zod": "^3.22.4"
+  },
+  "overrides": {
+    "form-data": "^4.0.4"
   }
 }

--- a/tests/utils/fromPartialProtobufObject.unit.test.ts
+++ b/tests/utils/fromPartialProtobufObject.unit.test.ts
@@ -2,6 +2,7 @@ import {
   LicenseType,
   Workflow,
   Model,
+  DeployRestriction,
 } from "clarifai-nodejs-grpc/proto/clarifai/api/resources_pb";
 import { describe, expect, it } from "vitest";
 import {
@@ -54,6 +55,8 @@ describe("fromPartialProtobufObject", () => {
             creator: "",
             versionCount: 0,
             billingType: Model.BillingType.UNKNOWN,
+            deployRestriction: DeployRestriction.NO_LIMITS,
+            replicaCount: 1,
           },
           nodeInputsList: [],
           suppressOutput: false,
@@ -97,6 +100,8 @@ describe("fromPartialProtobufObject", () => {
             creator: "",
             versionCount: 0,
             billingType: Model.BillingType.UNKNOWN,
+            deployRestriction: DeployRestriction.NO_LIMITS,
+            replicaCount: 1,
           },
           nodeInputsList: [],
           suppressOutput: false,
@@ -140,6 +145,8 @@ describe("fromPartialProtobufObject", () => {
             creator: "",
             versionCount: 0,
             billingType: Model.BillingType.UNKNOWN,
+            deployRestriction: DeployRestriction.NO_LIMITS,
+            replicaCount: 1,
           },
           nodeInputsList: [
             {


### PR DESCRIPTION
This pull request updates a dependency and introduces an override in the `package.json` file to ensure compatibility and resolve potential issues.

Dependency updates and overrides:

* Updated the `clarifai-nodejs-grpc` dependency from version `^11.4.3` to `^11.6.6`.
* Added an override for the `form-data` package to use version `^4.0.4`.