### PR TITLE
ci(deps/tests): Remove e2e and update fast-xml-parser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Run tests
-        run: npm run test
-        env:
-          VITE_CLARIFAI_USER_ID: ${{ secrets.VITE_CLARIFAI_USER_ID }}
-          VITE_CLARIFAI_PAT: ${{ secrets.VITE_CLARIFAI_PAT }}
+        run: npm run test:unit
       - name: Build
         run: npm run build

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -28,10 +28,7 @@ jobs:
       - name: "Lint"
         run: npm run lint
       - name: "Test"
-        run: npx vitest --coverage.enabled true
-        env:
-          VITE_CLARIFAI_USER_ID: ${{ secrets.VITE_CLARIFAI_USER_ID }}
-          VITE_CLARIFAI_PAT:  ${{ secrets.VITE_CLARIFAI_PAT }}
+        run: npx vitest --coverage.enabled true unit.test
       - name: Prepare Branch Name
         id: prepare
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7218,17 +7218,13 @@
       ]
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "zod": "^3.22.4"
   },
   "overrides": {
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.4",
+    "fast-xml-parser": "^4.5.4"
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/Clarifai/clarifai-nodejs/security/dependabot/76

This pull request makes adjustments to the test scripts in GitHub Actions workflows and updates package dependencies to improve test granularity and dependency management. The most important changes are grouped below by theme.

**CI/CD Workflow Improvements:**

* Changed the test command in `.github/workflows/build.yml` from `npm run test` to `npm run test:unit`, focusing the build workflow on unit tests only.
* Updated the test command in `.github/workflows/test-pr.yml` to run `npx vitest --coverage.enabled true unit.test` instead of all tests, ensuring only unit tests are executed during pull request validation.

**Dependency Management:**
* Added an override for the `fast-xml-parser` package in `package.json` to specify version `^4.5.4`, improving control over dependency versions.