### PR TITLE
fix: Security update for packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6510,9 +6510,9 @@
       "dev": true
     },
     "node_modules/convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.5.tgz",
+      "integrity": "sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "yargs-parser": "^20.2.7"
@@ -7669,9 +7669,9 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
     "zod": "^3.22.4"
   },
   "overrides": {
+    "convict": "^6.2.5",
     "form-data": "^4.0.4",
-    "fast-xml-parser": "^4.5.4"
+    "fast-xml-parser": "^4.5.4",
+    "handlebars": "^4.7.9"
   }
 }


### PR DESCRIPTION
This pull request updates the `package.json` file to add and update some dependency overrides. The most important changes are:

**Dependency Management:**

* Added an override for the `convict` package to version `^6.2.5`.
* Added an override for the `handlebars` package to version `^4.7.9`.