### PR TITLE
fix: Publish Action 🔧

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,8 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 name: Publish package to npm
 
 on:
-  repository_dispatch:
-    types: [publish-new-version]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,57 +10,9 @@ permissions:
   pull-requests: write
 
 jobs:
-
-  check_commit_message:
-    runs-on: ubuntu-latest
-    outputs:
-      patternMatch: ${{ steps.check_pattern.outputs.match }}
-      isReleaseComplete: ${{ steps.check_pattern.outputs.release_complete }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check for release pattern in commit message
-        id: check_pattern
-        run: |
-          PATTERN="Release-As: [0-9]+\.[0-9]+\.[0-9]+|release [0-9]+\.[0-9]+\.[0-9]+"
-          COMMIT_MESSAGE=$(git log --format=%B -n 1)
-          echo "Commit Message: $COMMIT_MESSAGE"
-          if [[ "$COMMIT_MESSAGE" =~ $PATTERN ]]; then
-            echo "Pattern found. Proceeding with the job."
-            echo "::set-output name=match::true"
-          else
-            echo "Pattern not found. Skipping subsequent steps."
-            echo "::set-output name=match::false"
-          fi
-          PATTERN="release [0-9]+\.[0-9]+\.[0-9]+"
-          COMMIT_MESSAGE=$(git log --format=%B -n 1)
-          echo "Commit Message: $COMMIT_MESSAGE"
-          if [[ "$COMMIT_MESSAGE" =~ $PATTERN ]]; then
-            echo "Pattern found. Proceeding with the job."
-            echo "::set-output name=release_complete::true"
-          else
-            echo "Pattern not found. Skipping subsequent steps."
-            echo "::set-output name=release_complete::false"
-          fi
-
   release-please:
-    needs: check_commit_message
     runs-on: ubuntu-latest
-    if: needs.check_commit_message.outputs.patternMatch == 'true'
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
           release-type: node
-
-  trigger-publish-dispatch:
-    name: "Trigger Publish Repository Dispatch Event"
-    needs: [release-please, check_commit_message]
-    runs-on: ubuntu-latest
-    if: needs.check_commit_message.outputs.isReleaseComplete == 'true'
-    steps:
-      - name: Create Release Repository Dispatch Event
-        id: create_release_dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          event-type: publish-new-version


### PR DESCRIPTION
The publish pipeline has two problems:

**1. The release-please workflow was over-engineered and broken**

Instead of letting release-please run on every push to main (its intended design), the workflow had a custom check_commit_message job that parsed commit messages with regex to decide whether to run release-please at all. This gate used the deprecated ::set-output syntax (GitHub Actions dropped support for it), so the outputs were silently empty — meaning the downstream jobs never ran.

Even when it did work, the flow was fragile: it dispatched a repository_dispatch event to trigger a separate publish workflow, adding an unnecessary hop. The 0.3.1 and 0.3.2 "release" commits were manual attempts to work around this — but because release-please never actually ran, package.json was never bumped past 0.3.0, no tags were created, and no GitHub Releases were made.

**2. The npm publish returned a 404**

The NPM_TOKEN secret is expired or invalid. npm returns 404 (not 401) on auth failures for security reasons. This requires regenerating the token on npmjs.com and updating the GitHub secret — a manual step.

What the fix does:

release-please.yml — Removes all the commit-message-parsing and repository-dispatch machinery. Release-please now runs on every push to main, which is the standard usage. It creates/updates a release PR automatically, and when that PR is merged, it creates a GitHub Release and tag.

npm-publish.yml — Changes the trigger from repository_dispatch: publish-new-version to release: published. This fires directly when release-please creates a GitHub Release, removing the fragile dispatch hop. workflow_dispatch is kept for manual publishes.