### PR TITLE
fix: security update for fast-uri dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7203,9 +7203,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "vite": "^6.4.2",
     "lodash-es": "^4.18.0",
     "postcss": "^8.5.10",
-    "picomatch@2": "^2.3.2"
+    "picomatch@2": "^2.3.2",
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
This pull request adds a new dependency to the project. The `fast-uri` package is now included in the `package.json` dependencies.

* Added (pinned) `fast-uri` version `^3.1.2` to the dependencies in `package.json` to support URI parsing or handling.