### PR TITLE
fix: suppress high level vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@parcel/packager-ts": "^2.15.2",
-        "@parcel/transformer-typescript-types": "^2.15.2",
+        "@parcel/packager-ts": "^2.16.4",
+        "@parcel/transformer-typescript-types": "^2.16.4",
         "@types/async": "^3.2.24",
         "@types/google-protobuf": "^3.15.12",
         "@types/js-yaml": "^4.0.9",
@@ -44,7 +44,7 @@
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "parcel": "^2.15.2",
+        "parcel": "^2.16.4",
         "prettier": "3.2.4",
         "typedoc": "^0.25.12",
         "typedoc-plugin-include-example": "^1.2.0",
@@ -1978,9 +1978,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
-      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
       ],
@@ -1991,9 +1991,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
-      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
       "cpu": [
         "x64"
       ],
@@ -2004,9 +2004,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
-      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
       "cpu": [
         "arm"
       ],
@@ -2017,9 +2017,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
-      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
       "cpu": [
         "arm64"
       ],
@@ -2030,9 +2030,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
-      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
       "cpu": [
         "x64"
       ],
@@ -2043,9 +2043,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
-      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "cpu": [
         "x64"
       ],
@@ -2111,31 +2111,53 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.15.2.tgz",
-      "integrity": "sha512-k0psV7OZYs1g6jcJweBjINVZaVTcfFr6PuCQr28biZ85qbc70f5pWzCzY963+dF3XO/QwTzDABZsJUiDf5jPfQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.16.4.tgz",
+      "integrity": "sha512-Nb8peNvhfm1+660CLwssWh4weY+Mv6vEGS6GPKqzJmTMw50udi0eS1YuWFzvmhSiu1KsYcUD37mqQ1LuIDtWoA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/graph": "3.5.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/graph": "3.6.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/cache": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.16.4.tgz",
+      "integrity": "sha512-+uCyeElSga2MBbmbXpIj/WVKH7TByCrKaxtHbelfKKIJpYMgEHVjO4cuc7GUfTrUAmRUS8ZGvnX7Etgq6/jQhw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "lmdb": "2.8.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.16.4"
+      }
+    },
     "node_modules/@parcel/codeframe": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.15.2.tgz",
-      "integrity": "sha512-uzcHUXBXV+vUqXE7SR6Et60GauPGTWvc381pVzCzc90VQJyWY/xyRRIgcA+4MLi2+lQj+w4Uq9H9qg+hMx/JFg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.4.tgz",
+      "integrity": "sha512-s64aMfOJoPrXhKH+Y98ahX0O8aXWvTR+uNlOaX4yFkpr4FFDnviLcGngDe/Yo4Qq2FJZ0P6dNswbJTUH9EGxkQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2"
@@ -2165,16 +2187,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.15.2.tgz",
-      "integrity": "sha512-p+Rr70kX6+bcFPtrrKFdNYnZzdSRSWXi8fvLzZtxissX2ANYS1oFdF6ia37pnzVlHhuYcN6HHMIHbDzJmRvMqA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.16.4.tgz",
+      "integrity": "sha512-IK8IpNhw61B2HKgA1JhGhO9y+ZJFRZNTEmvhN1NdLdPqvgEXm2EunT+m6D9z7xeoeT6XnUKqM0eRckEdD0OXbA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2182,74 +2204,74 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.15.2.tgz",
-      "integrity": "sha512-spJWqNnymehtESYM89d/E7P7WgFJ7PpOwr2Y1k1ItdEzuq87FZvudAs8bccXMHD69IgtEes+B0dUSEiOb8YlMQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.16.4.tgz",
+      "integrity": "sha512-kBxuTY/5trEVnvXk92l7LVkYjNuz3SaqWymFhPjEnc8GY4ZVdcWrWdXWTB9hUhpmRYJctFCyGvM0nN05JTiM2g==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.15.2",
-        "@parcel/compressor-raw": "2.15.2",
-        "@parcel/namer-default": "2.15.2",
-        "@parcel/optimizer-css": "2.15.2",
-        "@parcel/optimizer-html": "2.15.2",
-        "@parcel/optimizer-image": "2.15.2",
-        "@parcel/optimizer-svg": "2.15.2",
-        "@parcel/optimizer-swc": "2.15.2",
-        "@parcel/packager-css": "2.15.2",
-        "@parcel/packager-html": "2.15.2",
-        "@parcel/packager-js": "2.15.2",
-        "@parcel/packager-raw": "2.15.2",
-        "@parcel/packager-svg": "2.15.2",
-        "@parcel/packager-wasm": "2.15.2",
-        "@parcel/reporter-dev-server": "2.15.2",
-        "@parcel/resolver-default": "2.15.2",
-        "@parcel/runtime-browser-hmr": "2.15.2",
-        "@parcel/runtime-js": "2.15.2",
-        "@parcel/runtime-rsc": "2.15.2",
-        "@parcel/runtime-service-worker": "2.15.2",
-        "@parcel/transformer-babel": "2.15.2",
-        "@parcel/transformer-css": "2.15.2",
-        "@parcel/transformer-html": "2.15.2",
-        "@parcel/transformer-image": "2.15.2",
-        "@parcel/transformer-js": "2.15.2",
-        "@parcel/transformer-json": "2.15.2",
-        "@parcel/transformer-node": "2.15.2",
-        "@parcel/transformer-postcss": "2.15.2",
-        "@parcel/transformer-posthtml": "2.15.2",
-        "@parcel/transformer-raw": "2.15.2",
-        "@parcel/transformer-react-refresh-wrap": "2.15.2",
-        "@parcel/transformer-svg": "2.15.2"
+        "@parcel/bundler-default": "2.16.4",
+        "@parcel/compressor-raw": "2.16.4",
+        "@parcel/namer-default": "2.16.4",
+        "@parcel/optimizer-css": "2.16.4",
+        "@parcel/optimizer-html": "2.16.4",
+        "@parcel/optimizer-image": "2.16.4",
+        "@parcel/optimizer-svg": "2.16.4",
+        "@parcel/optimizer-swc": "2.16.4",
+        "@parcel/packager-css": "2.16.4",
+        "@parcel/packager-html": "2.16.4",
+        "@parcel/packager-js": "2.16.4",
+        "@parcel/packager-raw": "2.16.4",
+        "@parcel/packager-svg": "2.16.4",
+        "@parcel/packager-wasm": "2.16.4",
+        "@parcel/reporter-dev-server": "2.16.4",
+        "@parcel/resolver-default": "2.16.4",
+        "@parcel/runtime-browser-hmr": "2.16.4",
+        "@parcel/runtime-js": "2.16.4",
+        "@parcel/runtime-rsc": "2.16.4",
+        "@parcel/runtime-service-worker": "2.16.4",
+        "@parcel/transformer-babel": "2.16.4",
+        "@parcel/transformer-css": "2.16.4",
+        "@parcel/transformer-html": "2.16.4",
+        "@parcel/transformer-image": "2.16.4",
+        "@parcel/transformer-js": "2.16.4",
+        "@parcel/transformer-json": "2.16.4",
+        "@parcel/transformer-node": "2.16.4",
+        "@parcel/transformer-postcss": "2.16.4",
+        "@parcel/transformer-posthtml": "2.16.4",
+        "@parcel/transformer-raw": "2.16.4",
+        "@parcel/transformer-react-refresh-wrap": "2.16.4",
+        "@parcel/transformer-svg": "2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.2"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.15.2.tgz",
-      "integrity": "sha512-yIFtxeLPLbTkpNuXGmnBX1U51unxv+gRoH/I5IcyD/vRL2Kp/cQU6YJWTSGK5sWG1Fgo+1Z2DeYp914Yd4a1WQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.16.4.tgz",
+      "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/cache": "2.15.2",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/events": "2.15.2",
-        "@parcel/feature-flags": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/graph": "3.5.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/package-manager": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/profiler": "2.15.2",
-        "@parcel/rust": "2.15.2",
+        "@parcel/cache": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/graph": "3.6.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/package-manager": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/profiler": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
         "base-x": "^3.0.11",
         "browserslist": "^4.24.5",
         "clone": "^2.1.2",
@@ -2268,105 +2290,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/core/node_modules/@parcel/cache": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.15.2.tgz",
-      "integrity": "sha512-xYVNKWUHT5hCxo+9nBy9xm7NVfk/jswo+SrU12pXtJm4S5kyK7/PaNkiXxnDu/Hiec2s9BqG/7ny5WBX+i/fAw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/fs": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "lmdb": "2.8.5"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
-      }
-    },
-    "node_modules/@parcel/core/node_modules/@parcel/fs": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
-      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/feature-flags": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/types-internal": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.15.2"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
-      }
-    },
-    "node_modules/@parcel/core/node_modules/@parcel/node-resolver-core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
-      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/core/node_modules/@parcel/package-manager": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.15.2.tgz",
-      "integrity": "sha512-0n8QupNyXp9CJZV6LohBpAqopLecQrave4kHG/T9CeCeqlJcQnYs+N+zio4mPlv7jXpnJHy+CF96Ce2wy/n1+Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/node-resolver-core": "3.6.2",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2",
-        "@swc/core": "^1.11.24",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
-      }
-    },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.15.2.tgz",
-      "integrity": "sha512-lsIF59BgfLzN3SP5VM42pa9lilcotEoF42H2RgnqLe3KACcNcbbtvjyjlvac+iaSRix4gEkuZa6376X6p7DkFQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.4.tgz",
+      "integrity": "sha512-YN5CfX7lFd6yRLxyZT4Sj3sR6t7nnve4TdXSIqapXzQwL7Bw+sj79D95wTq2rCm3mzk5SofGxFAXul2/nG6gcQ==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
@@ -2381,9 +2308,9 @@
       }
     },
     "node_modules/@parcel/error-overlay": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.15.2.tgz",
-      "integrity": "sha512-bfDWkTQ4jCBUdOSynXo49pCPrVgtYSwobSxMeNhmwpdKbFvavj/09eZkAHikQgcrCF8gBwapik/U2YBTnFt0fg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.16.4.tgz",
+      "integrity": "sha512-e8KYKnMsfmQnqIhsUWBUZAXlDK30wkxsAGle1tZ0gOdoplaIdVq/WjGPatHLf6igLM76c3tRn2vw8jZFput0jw==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -2394,9 +2321,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.15.2.tgz",
-      "integrity": "sha512-CxXVuYz/K3sDIquM+3Pemxhppb8Q/mRayxqxZtXHoKbhiLBeyX+pLz2v9Hr0R7fiN6naV00IG48Zc5aArHXR4w==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.4.tgz",
+      "integrity": "sha512-slWQkBRAA7o0cN0BLEd+yCckPmlVRVhBZn5Pn6ktm4EzEtrqoMzMeJOxxH8TXaRzrQDYnTcnYIHFgXWd4kkUfg==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -2407,9 +2334,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.15.2.tgz",
-      "integrity": "sha512-6oiuLd3ypk4GY8X9/l/GrngzSddHW8yF8DrYA++TkaPDtTz4llanza/p7RIk/ltdV3hmBxnH4vjWtciJEcbQww==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.4.tgz",
+      "integrity": "sha512-nYdx53siKPLYikHHxfzgjzzgxdrjquK6DMnuSgOTyIdRG4VHdEN0+NqKijRLuVgiUFo/dtxc2h+amwqFENMw8w==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -2419,13 +2346,37 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/graph": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.5.2.tgz",
-      "integrity": "sha512-SsKKRPotNALU5R5r5WOsP+6FsuaNkk9L0Bmu1UzeyyrHiQPO1OVBYCsX+NtsGDAdDX7oOkGqgfkavJHrAG/BFA==",
+    "node_modules/@parcel/fs": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.16.4.tgz",
+      "integrity": "sha512-maCMOiVn7oJYZlqlfxgLne8n6tSktIT1k0AeyBp4UGWCXyeJUJ+nL7QYShFpKNLtMLeF0cEtgwRAknWzbcDS1g==",
       "dev": true,
       "dependencies": {
-        "@parcel/feature-flags": "2.15.2",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.16.4"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.16.4"
+      }
+    },
+    "node_modules/@parcel/graph": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.4.tgz",
+      "integrity": "sha512-Cj9yV+/k88kFhE+D+gz0YuNRpvNOCVDskO9pFqkcQhGbsGq6kg2XpZ9V7HlYraih31xf8Vb589bZOwjKIiHixQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/feature-flags": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -2437,13 +2388,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.15.2.tgz",
-      "integrity": "sha512-naF3dXcvO1lZvtCi6kCTaXhB1cqRwWkRifQRfEei+yp0QZqZF9dmWwZzMOefst/PTl3RaW014vrwFtiegdqsbQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.4.tgz",
+      "integrity": "sha512-QR8QLlKo7xAy9JBpPDAh0RvluaixqPCeyY7Fvo2K7hrU3r85vBNNi06pHiPbWoDmB4x1+QoFwMaGnJOHR+/fMA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/events": "2.15.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -2454,9 +2405,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.15.2.tgz",
-      "integrity": "sha512-qioxe3Gw/khhrZXeF3tmJeChoq70prxGqVhJylsnGimxHbxjLo3i8Jo8Thi36GiGcOTYSeyF/2tMo9BW2t2vqA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.4.tgz",
+      "integrity": "sha512-0+oQApAVF3wMcQ6d1ZfZ0JsRzaMUYj9e4U+naj6YEsFsFGOPp+pQYKXBf1bobQeeB7cPKPT3SUHxFqced722Hw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2"
@@ -2486,18 +2437,40 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.15.2.tgz",
-      "integrity": "sha512-2JtJjqKlJEv34OsZdyfAiRtTwNB/ulsStokCSB/fNCkfJPMtgWHDLFz17O7evJbWIoS1gQbIsmeS5GiMBfWdFw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.16.4.tgz",
+      "integrity": "sha512-CE+0lFg881sJq575EXxj2lKUn81tsS5itpNUUErHxit195m3PExyAhoXM6ed/SXxwi+uv+T5FS/jjDLBNuUFDA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.7.4.tgz",
+      "integrity": "sha512-b3VDG+um6IWW5CTod6M9hQsTX5mdIelKmam7mzxzgqg4j5hnycgTWqPMc9UxhYoUY/Q/PHfWepccNcKtvP5JiA==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2505,22 +2478,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.15.2.tgz",
-      "integrity": "sha512-czLiJPe2T2QXuGO3xBIM1a1OnR/UhTwY1efCZzo7CofzklNRu33CDLZuWC2Re/JK1+dO4fYBOs0rdWmGFB5acg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.16.4.tgz",
+      "integrity": "sha512-aqdXCtmvpcXYgJFGk2DtXF34wuM2TD1fZorKMrJdKB9sSkWVRs1tq6RAXQrbi0ZPDH9wfE/9An3YdkTex7RHuQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
+        "@parcel/utils": "2.16.4",
         "browserslist": "^4.24.5",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2528,18 +2501,18 @@
       }
     },
     "node_modules/@parcel/optimizer-html": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.15.2.tgz",
-      "integrity": "sha512-7jcvytsOfvdpXIehkZDD9nYzF5V8Dk6JULffDPA03deB8aiFhvPPXr2gr5h3hc/ZvO220dfAJ63Ie622y0BNrQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.16.4.tgz",
+      "integrity": "sha512-vg/R2uuSni+NYYUUV8m+5bz8p5zBv8wc/nNleoBnGuCDwn7uaUwTZ8Gt9CjZO8jjG0xCLILoc/TW+e2FF3pfgQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2547,42 +2520,42 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.15.2.tgz",
-      "integrity": "sha512-KCm70vpyIPO9Ml1ZDp2zg8ghPFUDqZ5zu1ZwLwm3SpP/rZYIb6Y/hPTVz/D17yJp6m4bBUVPNLI6Nl2Li4rktg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.16.4.tgz",
+      "integrity": "sha512-2RV54WnvMYr18lxSx7Zlx/DXpJwMzOiPxDnoFyvaUoYutvgHO6chtcgFgh1Bvw/PoI95vYzlTkZ8QfUOk5A0JA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.2"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/optimizer-svg": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.15.2.tgz",
-      "integrity": "sha512-qyOt5BliHB1Dvi8c9h/95qzC80+7gw3ygMRM+avzuhESLlsGimktBBMHi+L6S1TQFjcHsorCkpcTfu48Vx6hUw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.16.4.tgz",
+      "integrity": "sha512-22+BqIffCrVErg8y2XwhasbTaFNn75OKXZ3KTDBIfOSAZKLUKs1iHfDXETzTRN7cVcS+Q36/6EHd7N/RA8i1fg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2590,43 +2563,70 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.15.2.tgz",
-      "integrity": "sha512-Ej8Y0VkNRUl7jyX4Xd9C8vTHqHfPXH3kAaEndrc7K1ZfvGeIzw/7OytFJeyJ/KbEIW7XWWtd2r7KaFiEG/8SJA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.16.4.tgz",
+      "integrity": "sha512-+URqwnB6u1gqaLbG1O1DDApH+UVj4WCbK9No1fdxLBxQ9a84jyli25o1kK1hYB9Nb/JMyYNnEBfvYUW6RphOxw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
+        "@parcel/utils": "2.16.4",
         "@swc/core": "^1.11.24",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/packager-css": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.15.2.tgz",
-      "integrity": "sha512-LZrFXC8bj7isdfKZIPS8OhFUWgZNmGXZJVfl7KLUD4D8GfNX0yKxBb4wtdfuQjlr1KMyw0WluchTXads4oVcMg==",
+    "node_modules/@parcel/package-manager": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.16.4.tgz",
+      "integrity": "sha512-obWv9gZgdnkT3Kd+fBkKjhdNEY7zfOP5gVaox5i4nQstVCaVnDlMv5FwLEXwehL+WbwEcGyEGGxOHHkAFKk7Cg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/node-resolver-core": "3.7.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
+        "@swc/core": "^1.11.24",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.16.4"
+      }
+    },
+    "node_modules/@parcel/packager-css": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.16.4.tgz",
+      "integrity": "sha512-rWRtfiX+VVIOZvq64jpeNUKkvWAbnokfHQsk/js1s5jD4ViNQgPcNLiRaiIANjymqL6+dQqWvGUSW2a5FAZYfg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
+        "@parcel/utils": "2.16.4",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2634,19 +2634,19 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.15.2.tgz",
-      "integrity": "sha512-+uvMAZW3r2h1IS+UD3QfCmcFwJb3pPPyQOGK/ks5pYcY0Bqxfvco+5vAbMBofZ6b6RS9YCUvBtJbe1FFx4A3Jw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.16.4.tgz",
+      "integrity": "sha512-AWo5f6SSqBsg2uWOsX0gPX8hCx2iE6GYLg2Z4/cDy2mPlwDICN8/bxItEztSZFmObi+ti26eetBKRDxAUivyIQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2654,23 +2654,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.15.2.tgz",
-      "integrity": "sha512-kEXuKduZH/ynxm5zOUZSp6kV+/eyKbHn+zILXfFB7VeHuNyATfm8GTcSUhLYFHAoOncXorE51KI6KDMuKPejjA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.16.4.tgz",
+      "integrity": "sha512-L2o39f/fhta+hxto7w8OTUKdstY+te5BmHZREckbQm0KTBg93BG7jB0bfoxLSZF0d8uuAYIVXjzeHNqha+du1g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "globals": "^13.24.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2678,16 +2678,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.15.2.tgz",
-      "integrity": "sha512-S4Gve8k9+qUj2c3wmbNmMQNqwsJ6E6o7ww/Z3CZ1M1i6UcegRVnK1usElw+6+j2L1sXdt/6pIUZvCg3DA9j3sA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.16.4.tgz",
+      "integrity": "sha512-A9j60G9OmbTkEeE4WRMXCiErEprHLs9NkUlC4HXCxmSrPMOVaMaMva2LdejE3A9kujZqYtYfuc8+a+jN+Nro4w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2695,19 +2695,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.15.2.tgz",
-      "integrity": "sha512-oTdoPl1mcJ0JeKPz5/ZZFlM+UM9YNsutRm8l6H2k6dcht2mbOt8e0OZQcRIiHmTcY8eEsF3bXmo/qXWB+PcihA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.16.4.tgz",
+      "integrity": "sha512-LT9l7eInFrAZJ6w3mYzAUgDq3SIzYbbQyW46Dz26M9lJQbf6uCaATUTac3BEHegW0ikDuw4OOGHK41BVqeeusg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2715,16 +2715,16 @@
       }
     },
     "node_modules/@parcel/packager-ts": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.15.2.tgz",
-      "integrity": "sha512-y69nPhsTzQ2C148JR8roLr2+ldUnq3e46A9uaVC05Vrlbqwkc/obJNU0u6tekbxEBKI7agA8YZPxYGOai1wOLg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.16.4.tgz",
+      "integrity": "sha512-VjHX/8GFPir+BUyGapgs/8uqymddx5KWt/Fmd2ozyAcRC6rGY7oYAiAPTrTen37KWMSrfZYuNOubZcVWiMAqQg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2732,16 +2732,16 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.15.2.tgz",
-      "integrity": "sha512-LqDdXeC/cbjGc4qZjOJvpx4PmuQL0+kQVmO3AvnUIee+C2T2LgdTG7qhzJGJcihdvkvxZjKZI9fQgrjy9EFDuA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.4.tgz",
+      "integrity": "sha512-AY96Aqu/RpmaSZK2RGkIrZWjAperDw8DAlxLAiaP1D/RPVnikZtl5BmcUt/Wz3PrzG7/q9ZVqqKkWsLmhkjXZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2749,12 +2749,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.15.2.tgz",
-      "integrity": "sha512-5ii1OpD/lGdpvy5AS1jChpCwEZP0eFaucy8szOjmfl4oZIeaHRHbZ5R0/3O1Hy8tY1IJF87HUKd+XV0iyD48zA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.4.tgz",
+      "integrity": "sha512-aN2VQoRGC1eB41ZCDbPR/Sp0yKOxe31oemzPx1nJzOuebK2Q6FxSrJ9Bjj9j/YCaLzDtPwelsuLOazzVpXJ6qg==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.15.2"
+        "@parcel/types": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -2765,14 +2765,14 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.15.2.tgz",
-      "integrity": "sha512-hLTI6TIRr/tGgjTbsCqW4Avl2x8FMAHLDlDhNYjivX6ccfZmilEJnIcdKr2QtdgcaSulfRLTd5bt6uJWJ2ecKg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.4.tgz",
+      "integrity": "sha512-R3JhfcnoReTv2sVFHPR2xKZvs3d3IRrBl9sWmAftbIJFwT4rU70/W7IdwfaJVkD/6PzHq9mcgOh1WKL4KAxPdA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/events": "2.15.2",
-        "@parcel/types-internal": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -2784,20 +2784,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.15.2.tgz",
-      "integrity": "sha512-R2WuHr+0FafsR9WNibR8ssyX8bHwXzMA91OdmeLMaAG5Dc/xv6yTIZuvOCdlCAfbBkcRiMnLWTQ3hQI1bqkC4g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.16.4.tgz",
+      "integrity": "sha512-DQx9TwcTZrDv828+tcwEi//xyW7OHTGzGX1+UEVxPp0mSzuOmDn0zfER8qNIqGr1i4D/FXhb5UJQDhGHV8mOpQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2821,19 +2821,19 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.15.2.tgz",
-      "integrity": "sha512-xJzb+IfcZfD2Ml4GYhHFovQ4vbWpFP/bd9cM9TuzyfCbaaf0NEN18uY3kRFCUDYOWs7aLOMzqL3eI5Hw6zh+Pw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.16.4.tgz",
+      "integrity": "sha512-YWvay25htQDifpDRJ0+yFh6xUxKnbfeJxYkPYyuXdxpEUhq4T0UWW0PbPCN/wFX7StgeUTXq5Poeo/+eys9m3w==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/codeframe": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2"
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2841,19 +2841,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.15.2.tgz",
-      "integrity": "sha512-jtmNPMXVuuqO4WmIgYifAtKhMWblAZmRnqc5dVZfUBWPeqGKrbH2k89cYtZfvMbLon8/Glv6WDOt91oyDfjuKg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.16.4.tgz",
+      "integrity": "sha512-JKnlXpPepak0/ZybmZn9JtyjJiDBWYrt7ZUlXQhQb0xzNcd/k+RqfwVkTKIwyFHsWtym0cwibkvsi2bWFzS7tw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2861,63 +2861,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.15.2.tgz",
-      "integrity": "sha512-CuCCPEu3jwyLplbLDrahq0CstmIHchKefmX0JGpqCJBJBVdO89SHV5hUr8Se7hfy8uamD41wW10d51oAmyjXMA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.16.4.tgz",
+      "integrity": "sha512-wJe9XQS0hn/t32pntQpJbls3ZL8mGVVhK9L7s7BTmZT9ufnvP2nif1psJz/nbgnP9LF6mLSk43OdMJKpoStsjQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.6.2",
-        "@parcel/plugin": "2.15.2"
+        "@parcel/node-resolver-core": "3.7.4",
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/resolver-default/node_modules/@parcel/fs": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
-      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/feature-flags": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/types-internal": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.15.2"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
-      }
-    },
-    "node_modules/@parcel/resolver-default/node_modules/@parcel/node-resolver-core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
-      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2925,17 +2879,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.15.2.tgz",
-      "integrity": "sha512-4QtuKAT3NphDrGpRVXyGOrG/gR6cjLIqPkqamTEuAVc13bmjK9XJ5Q4l1L3kjIIlQrRPg9MlHJcZ7VR3PuWWRQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.16.4.tgz",
+      "integrity": "sha512-asx7p3NjUSfibI3bC7+8+jUIGHWVk2Zuq9SjJGCGDt+auT9A4uSGljnsk1BWWPqqZ0WILubq4czSAqm0+wt4cw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2943,19 +2897,19 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.15.2.tgz",
-      "integrity": "sha512-5GGL/7rH6N54u7lAjX8mJKsumFiCyUcpz9wbygG4gkzMcRmGRnp+tctKI9f0GPfcMfKhdypOHfduc5SAuMX03w==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.16.4.tgz",
+      "integrity": "sha512-gUKmsjg+PULQBu2QbX0QKll9tXSqHPO8NrfxHwWb2lz5xDKDos1oV0I7BoMWbHhUHkoToXZrm654oGViujtVUA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2963,19 +2917,19 @@
       }
     },
     "node_modules/@parcel/runtime-rsc": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.15.2.tgz",
-      "integrity": "sha512-k0cYvrPUXpvV+neplTkJ1P/LkJzQmtF4eU3js+/kzyOU3zhUSgrLNHJmj6ibuWVYHENW2QtasvpsXjvE2knqTg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.16.4.tgz",
+      "integrity": "sha512-CHkotYE/cNiUjJmrc5FD9YhlFp1UF5wMNNJmoWaL40eBzsqcaV0sSn5V3bNapwewn3wrMYgdPgvOTHfaZaG73A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2983,18 +2937,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.15.2.tgz",
-      "integrity": "sha512-5+nV46pqa+7xFscLr4NRSeyXR8i+PSOoECRUzrv4UJRVbeCeE4bfqMYXs+rMbSrBillOLZyydNUQUT56xo9W6A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.16.4.tgz",
+      "integrity": "sha512-FT0Q58bf5Re+dq5cL2XHbxqHHFZco6qtRijeVpT3TSPMRPlniMArypSytTeZzVNL7h/hxjWsNu7fRuC0yLB5hA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3002,9 +2956,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.15.2.tgz",
-      "integrity": "sha512-6ZIVsSnkwxvDDVaxiYK4bWtVaJBYaFQuRvcxfCMQHEzFpWl9mdZVbCs3+g69Ere7a3e2sk87B41d/FIhoaz5xw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.4.tgz",
+      "integrity": "sha512-RBMKt9rCdv6jr4vXG6LmHtxzO5TuhQvXo1kSoSIF7fURRZ81D1jzBtLxwLmfxCPsofJNqWwdhy5vIvisX+TLlQ==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -3014,14 +2968,14 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/rust-darwin-arm64": "2.15.2",
-        "@parcel/rust-darwin-x64": "2.15.2",
-        "@parcel/rust-linux-arm-gnueabihf": "2.15.2",
-        "@parcel/rust-linux-arm64-gnu": "2.15.2",
-        "@parcel/rust-linux-arm64-musl": "2.15.2",
-        "@parcel/rust-linux-x64-gnu": "2.15.2",
-        "@parcel/rust-linux-x64-musl": "2.15.2",
-        "@parcel/rust-win32-x64-msvc": "2.15.2"
+        "@parcel/rust-darwin-arm64": "2.16.4",
+        "@parcel/rust-darwin-x64": "2.16.4",
+        "@parcel/rust-linux-arm-gnueabihf": "2.16.4",
+        "@parcel/rust-linux-arm64-gnu": "2.16.4",
+        "@parcel/rust-linux-arm64-musl": "2.16.4",
+        "@parcel/rust-linux-x64-gnu": "2.16.4",
+        "@parcel/rust-linux-x64-musl": "2.16.4",
+        "@parcel/rust-win32-x64-msvc": "2.16.4"
       },
       "peerDependencies": {
         "napi-wasm": "^1.1.2"
@@ -3033,9 +2987,9 @@
       }
     },
     "node_modules/@parcel/rust-darwin-arm64": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.15.2.tgz",
-      "integrity": "sha512-IK5mo/7bNym1ODMWD92D2URGcAq2K/9BasRlfjWI/Gh74l3lH4EFadUfgM88L+MVCV3WTg8ht5ZA0Iyp+IQ1JQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.4.tgz",
+      "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q==",
       "cpu": [
         "arm64"
       ],
@@ -3053,9 +3007,9 @@
       }
     },
     "node_modules/@parcel/rust-darwin-x64": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.15.2.tgz",
-      "integrity": "sha512-J30ukJXCzXsYNlYvYsaPEAEzfCZGXVIkXtPSVpWPwcaReqFUyT2bm4I8DHoeas0JwMNaeNlJhksaJA/iomqlwA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.4.tgz",
+      "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA==",
       "cpu": [
         "x64"
       ],
@@ -3073,9 +3027,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm-gnueabihf": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.15.2.tgz",
-      "integrity": "sha512-WpPddkviw8IkRRnT/dRyD3Uzvy6Yuoy5vvtDmpnrR2bJnEz5uQI3TlhMtQo7R+j6aIrDsGFJKBeo9Z0ga0ebNQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.4.tgz",
+      "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA==",
       "cpu": [
         "arm"
       ],
@@ -3093,9 +3047,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm64-gnu": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.15.2.tgz",
-      "integrity": "sha512-RzD7Gw0QqyUoWaVrtCU+v5J5pg6bybVNknqlEY4jfcJDgJHsM1V91DwJwxnI4ikG/uMedl0I40dl59x/Vo01Ow==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.4.tgz",
+      "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ==",
       "cpu": [
         "arm64"
       ],
@@ -3113,9 +3067,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm64-musl": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.15.2.tgz",
-      "integrity": "sha512-mWoL7kCITrEOO0GQ+LqGUylX+6b3nsV60Lzrz2N0Pgzz3EbGS0d4gDKkjxpi6BoR+h4KL7nLhj4hhbm0OHIc4A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.4.tgz",
+      "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA==",
       "cpu": [
         "arm64"
       ],
@@ -3133,9 +3087,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-x64-gnu": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.15.2.tgz",
-      "integrity": "sha512-aI8bKZTEZNYmgURiAfrgpmaoEArnMRvosfsOKnGykTjmHgsBxO/CGguFj5a4wlAZTVWcTGfs4krnUKtF9Hw6Rw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.4.tgz",
+      "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg==",
       "cpu": [
         "x64"
       ],
@@ -3153,9 +3107,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-x64-musl": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.15.2.tgz",
-      "integrity": "sha512-FpQOraPTjGfbHipjdbYpQLlMIRDoVL+Kl9ak+6mt0SbvP3QaXGosQXyhw0ZoNszqVLjIwC0OHEjAHdtcO6ZUvQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.4.tgz",
+      "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA==",
       "cpu": [
         "x64"
       ],
@@ -3173,9 +3127,9 @@
       }
     },
     "node_modules/@parcel/rust-win32-x64-msvc": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.15.2.tgz",
-      "integrity": "sha512-aSXkPc+KYAT6MnYgw2urXuDvipPkD90uJBKtSn3MY+fGOfzEluK7j0F5NdH88oTzrGVhRQxnxfe3Fc+IRhsaFQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.4.tgz",
+      "integrity": "sha512-TcpWC3I1mJpfP2++018lgvM7UX0P8IrzNxceBTHUKEIDMwmAYrUKAQFiaU0j1Ldqk6yP8SPZD3cvphumsYpJOQ==",
       "cpu": [
         "x64"
       ],
@@ -3205,15 +3159,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.15.2.tgz",
-      "integrity": "sha512-9oGx0wJhKY+Lh6PLY05m36IS6r6oOxpAQZhna2S5AYcfcf10ZsL8afOJTE8JBXbfg35dp97jeB4iuSHYTXr6NA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.16.4.tgz",
+      "integrity": "sha512-CMDUOQYX7+cmeyHxHSFnoPcwvXNL7rRFE+Q06uVFzsYYiVhbwGF/1J5Bx4cW3Froumqla4YTytTsEteJEybkdA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
+        "@parcel/utils": "2.16.4",
         "browserslist": "^4.24.5",
         "json5": "^2.2.3",
         "nullthrows": "^1.1.1",
@@ -3221,7 +3175,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3229,22 +3183,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.15.2.tgz",
-      "integrity": "sha512-NlybdCOr8r0LiPc7FIkeZp0mjfVB0Ht9B9eM3gUf2rOA1iM9/KGZNlu1AKVInyLRerybFqrGwHgx/qMGmbL3JA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.16.4.tgz",
+      "integrity": "sha512-VG/+DbDci2HKe20GFRDs65ZQf5GUFfnmZAa1BhVl/MO+ijT3XC3eoVUy5cExRkq4VLcPY4ytL0g/1T2D6x7lBQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
+        "@parcel/utils": "2.16.4",
         "browserslist": "^4.24.5",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3252,18 +3206,18 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.15.2.tgz",
-      "integrity": "sha512-P0xptyNVKTgXr6HovvL3kCUw7eA3s2aZpAdliOhnFfzXUCG6Na/XN8TW5TOiNo41bcxsYwLpfrZz0N20AVJ4qw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.16.4.tgz",
+      "integrity": "sha512-w6JErYTeNS+KAzUAER18NHFIFFvxiLGd4Fht1UYcb/FDjJdLAMB/FljyEs0Rto/WAhZ2D0MuSL25HQh837R62g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3271,36 +3225,36 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.15.2.tgz",
-      "integrity": "sha512-5WpKkEDMppaO21MO/5Rikr+DDRjkh3mPalpnH/DQLNEv0fKOakSNWDRR7FuV5ozSVREeQurTvbb4tAFAxOQx1w==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.16.4.tgz",
+      "integrity": "sha512-ZzIn3KvvRqMfcect4Dy+57C9XoQXZhpVJKBdQWMp9wM1qJEgsVgGDcaSBYCs/UYSKMRMP6Wm20pKCt408RkQzg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.2"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.15.2.tgz",
-      "integrity": "sha512-zVDc5Pc3/Cbn3GGsGjj+k/WjQLJCdwsKlYfpYiTXvSuXDpb4FCcYgr6F+wbSHb+/VikYIVH1RwH4kjCuIuNtew==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.16.4.tgz",
+      "integrity": "sha512-FD2fdO6URwAGBPidb3x1dDgLBt972mko0LelcSU05aC/pcKaV9mbCtINbPul1MlStzkxDelhuImcCYIyerheVQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.24.5",
         "nullthrows": "^1.1.1",
@@ -3309,28 +3263,28 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.2"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.15.2.tgz",
-      "integrity": "sha512-ycGhhk+DeipU0jtdGZesIx0X++h3qLkT77N6B2cTyD+BXAlKYUh++QIaLyDgTu7VwqSIt5msDg5jLWdamH7Rkw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.16.4.tgz",
+      "integrity": "sha512-pB3ZNqgokdkBCJ+4G0BrPYcIkyM9K1HVk0GvjzcLEFDKsoAp8BGEM68FzagFM/nVq9anYTshIaoh349GK0M/bg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
+        "@parcel/plugin": "2.16.4",
         "json5": "^2.2.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3338,16 +3292,16 @@
       }
     },
     "node_modules/@parcel/transformer-node": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.15.2.tgz",
-      "integrity": "sha512-H3IsKE2nVSEnqQH0DtjHQTTPqRw3gdXv9dROlwkU53O3cAIAtHDJYWmmDLMqhLl68vOYTvlkDT03rGrjnk8rDg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.16.4.tgz",
+      "integrity": "sha512-7t43CPGfMJk1LqFokwxHSsRi+kKC2QvDXaMtqiMShmk50LCwn81WgzuFvNhMwf6lSiBihWupGwF3Fqksg+aisg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3355,15 +3309,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.15.2.tgz",
-      "integrity": "sha512-3vLJqsFhOwsUS6lFnBZhU//OrfdLPM4uPBsm7XDLl45B2+FcW3T2H32uSGW6Ue1q1MawkVeNShuy293luh7gmA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.16.4.tgz",
+      "integrity": "sha512-jfmh9ho03H+qwz9S1b/a/oaOmgfMovtHKYDweIGMjKULKIee3AFRqo8RZIOuUMjDuqHWK8SqQmjery4syFV3Xw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "clone": "^2.1.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3371,7 +3325,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3379,17 +3333,17 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.15.2.tgz",
-      "integrity": "sha512-khdk3IfQLnlryu695kEDQHsvw02jGSJsbgqHoOdIxEbMltxB1JMfJBOOiTm+JEXXQlgD1ttX59CQD4vC7sIT0Q==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.16.4.tgz",
+      "integrity": "sha512-+GXsmGx1L25KQGQnwclgEuQe1t4QU+IoDkgN+Ikj+EnQCOWG4/ts2VpMBeqP5F18ZT4cCSRafj6317o/2lSGJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3397,16 +3351,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.15.2.tgz",
-      "integrity": "sha512-c/7rzEnpWJJmQbZiwFgL57ETUIIiiySBoVmtuF22yNjGQc1Znthg/ee8pT755UfE1hDCT6Kh/XLWv1Bt3C64CQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.16.4.tgz",
+      "integrity": "sha512-7WDUPq+bW11G9jKxaQIVL+NPGolV99oq/GXhpjYip0SaGaLzRCW7gEk60cftuk0O7MsDaX5jcAJm3G/AX+LJKg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.15.2"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3414,19 +3368,19 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.15.2.tgz",
-      "integrity": "sha512-ReH5qjJbT1Tj7ZYi1KIck2amNTiWqY6m31Ml3I6JeApg7djnz+EwbzPmbpKkcFmR+wxt82DtQdXO3Y7BOJsZDQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.16.4.tgz",
+      "integrity": "sha512-MiLNZrsGQJTANKKa4lzZyUbGj/en0Hms474mMdQkCBFg6GmjfmXwaMMgtTfPA3ZwSp2+3LeObCyca/f9B2gBZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/error-overlay": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/error-overlay": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "react-refresh": "^0.16.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3434,18 +3388,18 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.15.2.tgz",
-      "integrity": "sha512-R5Q0JgDtywSmojvqqa6TDmXDbKCfBBgu4tR0mzo3VicEObmiatRT49BFWHbdenfTf5tKpRplfH88leMPuDVVAg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.16.4.tgz",
+      "integrity": "sha512-0dm4cQr/WpfQP6N0xjFtwdLTxcONDfoLgTOMk4eNUWydHipSgmLtvUk/nOc/FWkwztRScfAObtZXOiPOd3Oy9A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
-        "@parcel/rust": "2.15.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3453,21 +3407,21 @@
       }
     },
     "node_modules/@parcel/transformer-typescript-types": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.15.2.tgz",
-      "integrity": "sha512-fEHw2ONaSPmWHCwtKx8MEc6zELDoAwxHoHFe0uhuMWBERkM2Ntgig7TEl8dQ0Y2UrQdOnPrJlsKu6TsPmr02+g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.16.4.tgz",
+      "integrity": "sha512-Cec1U3iqt7Dsqa17W8PXhfiqn+qlJntwp62Sq2z4S/ud1dkXZuURWeCkLGb5dB/DgNi3Xp0IeQxlSNoKNd/WJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/plugin": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/ts-utils": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/ts-utils": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.2"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3478,9 +3432,9 @@
       }
     },
     "node_modules/@parcel/ts-utils": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.15.2.tgz",
-      "integrity": "sha512-xdehXMsxjs56+vGamD3vKAO+e8cbUlxUOFPCVz6nuvQ9KfQ+PgpLQwPuPvvGdDkj75YbzCJks19C9lvpIg251g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.16.4.tgz",
+      "integrity": "sha512-hOYaQvtyq72jKqBjhtSBVn8vATZuaLnvauVRSDPH1DFOgQaPnM1r71Gw5djx6KMk+Tcpa5NyHNJmLVlVAIQ2tA==",
       "dev": true,
       "dependencies": {
         "nullthrows": "^1.1.1"
@@ -3497,38 +3451,38 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.15.2.tgz",
-      "integrity": "sha512-APVvBVVG8RIMLN5hERa2POkPkEtrNUqRbQlKpoNYlIYZaYxKzb9+4MH4cVkmkGfYk3FGU3K5RnxSxMMWsu4tdw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.4.tgz",
+      "integrity": "sha512-ctx4mBskZHXeDVHg4OjMwx18jfYH9BzI/7yqbDQVGvd5lyA+/oVVzYdpele2J2i2sSaJ87cA8nb57GDQ8kHAqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/types-internal": "2.15.2",
-        "@parcel/workers": "2.15.2"
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/workers": "2.16.4"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.15.2.tgz",
-      "integrity": "sha512-nmMpYeG4le49nvr8FsJYGEwhCZxcrm89tvkX8xGod1yXcShEZNWVVY9ezZLKxMrVMdBveqNUW8IZCij5iFDqdQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.4.tgz",
+      "integrity": "sha512-PE6Qmt5cjzBxX+6MPLiF7r+twoC+V9Skt3zyuBQ+H1c0i9o07Bbz2NKX10nvlPukfmW6Fu/1RvTLkzBZR1bU6A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/feature-flags": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.11.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.15.2.tgz",
-      "integrity": "sha512-SQ77yZyeLZf5Teq5aMAViuXKoN7JRnYZ7Pdere1FD8ZuS7E34THA4jjJKxKu9Bqtezgm+gpN1gMbSKMBfbmIZA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.4.tgz",
+      "integrity": "sha512-lkmxQHcHyOWZLbV8t+h2CGZIkPiBurLm/TS5wNT7+tq0qt9KbVwL7FP2K93TbXhLMGTmpI79Bf3qKniPM167Mw==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.15.2",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/markdown-ansi": "2.15.2",
-        "@parcel/rust": "2.15.2",
+        "@parcel/codeframe": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/markdown-ansi": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -3558,16 +3512,16 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.0.tgz",
-      "integrity": "sha512-XJLGVL0DEclX5pcWa2N9SX1jCGTDd8l972biNooLFtjneuGqodupPQh6XseXIBBeVIMaaJ7bTcs3qGvXwsp4vg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -3577,24 +3531,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.4.0",
-        "@parcel/watcher-darwin-arm64": "2.4.0",
-        "@parcel/watcher-darwin-x64": "2.4.0",
-        "@parcel/watcher-freebsd-x64": "2.4.0",
-        "@parcel/watcher-linux-arm-glibc": "2.4.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.4.0",
-        "@parcel/watcher-linux-arm64-musl": "2.4.0",
-        "@parcel/watcher-linux-x64-glibc": "2.4.0",
-        "@parcel/watcher-linux-x64-musl": "2.4.0",
-        "@parcel/watcher-win32-arm64": "2.4.0",
-        "@parcel/watcher-win32-ia32": "2.4.0",
-        "@parcel/watcher-win32-x64": "2.4.0"
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.0.tgz",
-      "integrity": "sha512-+fPtO/GsbYX1LJnCYCaDVT3EOBjvSFdQN9Mrzh9zWAOOfvidPWyScTrHIZHHfJBvlHzNA0Gy0U3NXFA/M7PHUA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
       "cpu": [
         "arm64"
       ],
@@ -3612,9 +3567,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.0.tgz",
-      "integrity": "sha512-T/At5pansFuQ8VJLRx0C6C87cgfqIYhW2N/kBfLCUvDhCah0EnLLwaD/6MW3ux+rpgkpQAnMELOCTKlbwncwiA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
       "cpu": [
         "arm64"
       ],
@@ -3632,9 +3587,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.0.tgz",
-      "integrity": "sha512-vZMv9jl+szz5YLsSqEGCMSllBl1gU1snfbRL5ysJU03MEa6gkVy9OMcvXV1j4g0++jHEcvzhs3Z3LpeEbVmY6Q==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
       "cpu": [
         "x64"
       ],
@@ -3652,9 +3607,9 @@
       }
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.0.tgz",
-      "integrity": "sha512-dHTRMIplPDT1M0+BkXjtMN+qLtqq24sLDUhmU+UxxLP2TEY2k8GIoqIJiVrGWGomdWsy5IO27aDV1vWyQ6gfHA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
       "cpu": [
         "x64"
       ],
@@ -3672,9 +3627,29 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.0.tgz",
-      "integrity": "sha512-9NQXD+qk46RwATNC3/UB7HWurscY18CnAPMTFcI9Y8CTbtm63/eex1SNt+BHFinEQuLBjaZwR2Lp+n7pmEJPpQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
       ],
@@ -3692,9 +3667,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.0.tgz",
-      "integrity": "sha512-QuJTAQdsd7PFW9jNGaV9Pw+ZMWV9wKThEzzlY3Lhnnwy7iW23qtQFPql8iEaSFMCVI5StNNmONUopk+MFKpiKg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
       "cpu": [
         "arm64"
       ],
@@ -3712,9 +3687,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.0.tgz",
-      "integrity": "sha512-oyN+uA9xcTDo/45bwsd6TFHa7Lc7hKujyMlvwrCLvSckvWogndCEoVYFNfZ6JJ2KNL/6fFiGPcbjp8jJmEh5Ng==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
       ],
@@ -3732,9 +3707,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.0.tgz",
-      "integrity": "sha512-KphV8awJmxU3q52JQvJot0QMu07CIyEjV+2Tb2ZtbucEgqyRcxOBDMsqp1JNq5nuDXtcCC0uHQICeiEz38dPBQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
       "cpu": [
         "x64"
       ],
@@ -3752,9 +3727,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.0.tgz",
-      "integrity": "sha512-7jzcOonpXNWcSijPpKD5IbC6xC7yTibjJw9jviVzZostYLGxbz8LDJLUnLzLzhASPlPGgpeKLtFUMjAAzM+gSA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
       ],
@@ -3772,9 +3747,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.0.tgz",
-      "integrity": "sha512-NOej2lqlq8bQNYhUMnOD0nwvNql8ToQF+1Zhi9ULZoG+XTtJ9hNnCFfyICxoZLXor4bBPTOnzs/aVVoefYnjIg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
       "cpu": [
         "arm64"
       ],
@@ -3792,9 +3767,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.0.tgz",
-      "integrity": "sha512-IO/nM+K2YD/iwjWAfHFMBPz4Zqn6qBDqZxY4j2n9s+4+OuTSRM/y/irksnuqcspom5DjkSeF9d0YbO+qpys+JA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
       "cpu": [
         "ia32"
       ],
@@ -3812,9 +3787,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.0.tgz",
-      "integrity": "sha512-pAUyUVjfFjWaf/pShmJpJmNxZhbMvJASUpdes9jL6bTEJ+gDxPRSpXTIemNyNsb9AtbiGXs9XduP1reThmd+dA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
       "cpu": [
         "x64"
       ],
@@ -3831,17 +3806,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@parcel/workers": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.15.2.tgz",
-      "integrity": "sha512-uQWM3Zzkk+vzFYrLQvU/oeM1LC6/EDPvpdgtvdwkUqYC6O1Oei+9cWz6Uv5UDCwizeJKt+3PyE2rB9idbEkmsQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.4.tgz",
+      "integrity": "sha512-dkBEWqnHXDZnRbTZouNt4uEGIslJT+V0c8OH1MPOfjISp1ucD6/u9ET8k9d/PxS9h1hL53og0SpBuuSEPLDl6A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/profiler": "2.15.2",
-        "@parcel/types-internal": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/profiler": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3852,7 +3836,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.2"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@petamoriken/float16": {
@@ -3875,9 +3859,9 @@
       }
     },
     "node_modules/@pinecone-database/pinecone/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3997,9 +3981,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
-      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -4010,9 +3994,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
-      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -4023,9 +4007,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
-      "integrity": "sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -4036,9 +4020,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
-      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -4049,9 +4033,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
-      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -4062,9 +4046,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
-      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -4075,9 +4059,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
-      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -4088,9 +4072,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
-      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -4101,9 +4085,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
-      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -4114,9 +4098,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
-      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -4126,10 +4110,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
-      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
@@ -4139,10 +4123,36 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
-      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -4153,9 +4163,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
-      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -4166,9 +4176,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
-      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4179,9 +4189,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
-      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -4192,9 +4202,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -4205,9 +4215,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
-      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -4217,10 +4227,36 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
-      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -4231,9 +4267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
-      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -4243,10 +4279,23 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
-      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -4985,14 +5034,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.29.tgz",
-      "integrity": "sha512-g4mThMIpWbNhV8G2rWp5a5/Igv8/2UFRJx2yImrLGMgrDDYZIopqZ/z0jZxDgqNA1QDx93rpwNF7jGsxVWcMlA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
+      "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.21"
+        "@swc/types": "^0.1.26"
       },
       "engines": {
         "node": ">=10"
@@ -5002,16 +5051,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.11.29",
-        "@swc/core-darwin-x64": "1.11.29",
-        "@swc/core-linux-arm-gnueabihf": "1.11.29",
-        "@swc/core-linux-arm64-gnu": "1.11.29",
-        "@swc/core-linux-arm64-musl": "1.11.29",
-        "@swc/core-linux-x64-gnu": "1.11.29",
-        "@swc/core-linux-x64-musl": "1.11.29",
-        "@swc/core-win32-arm64-msvc": "1.11.29",
-        "@swc/core-win32-ia32-msvc": "1.11.29",
-        "@swc/core-win32-x64-msvc": "1.11.29"
+        "@swc/core-darwin-arm64": "1.15.33",
+        "@swc/core-darwin-x64": "1.15.33",
+        "@swc/core-linux-arm-gnueabihf": "1.15.33",
+        "@swc/core-linux-arm64-gnu": "1.15.33",
+        "@swc/core-linux-arm64-musl": "1.15.33",
+        "@swc/core-linux-ppc64-gnu": "1.15.33",
+        "@swc/core-linux-s390x-gnu": "1.15.33",
+        "@swc/core-linux-x64-gnu": "1.15.33",
+        "@swc/core-linux-x64-musl": "1.15.33",
+        "@swc/core-win32-arm64-msvc": "1.15.33",
+        "@swc/core-win32-ia32-msvc": "1.15.33",
+        "@swc/core-win32-x64-msvc": "1.15.33"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -5023,9 +5074,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.29.tgz",
-      "integrity": "sha512-whsCX7URzbuS5aET58c75Dloby3Gtj/ITk2vc4WW6pSDQKSPDuONsIcZ7B2ng8oz0K6ttbi4p3H/PNPQLJ4maQ==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
+      "integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
       "cpu": [
         "arm64"
       ],
@@ -5039,9 +5090,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.29.tgz",
-      "integrity": "sha512-S3eTo/KYFk+76cWJRgX30hylN5XkSmjYtCBnM4jPLYn7L6zWYEPajsFLmruQEiTEDUg0gBEWLMNyUeghtswouw==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
+      "integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
       "cpu": [
         "x64"
       ],
@@ -5055,9 +5106,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.29.tgz",
-      "integrity": "sha512-o9gdshbzkUMG6azldHdmKklcfrcMx+a23d/2qHQHPDLUPAN+Trd+sDQUYArK5Fcm7TlpG4sczz95ghN0DMkM7g==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
+      "integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
       "cpu": [
         "arm"
       ],
@@ -5071,9 +5122,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.29.tgz",
-      "integrity": "sha512-sLoaciOgUKQF1KX9T6hPGzvhOQaJn+3DHy4LOHeXhQqvBgr+7QcZ+hl4uixPKTzxk6hy6Hb0QOvQEdBAAR1gXw==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
+      "integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
       "cpu": [
         "arm64"
       ],
@@ -5087,9 +5138,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.29.tgz",
-      "integrity": "sha512-PwjB10BC0N+Ce7RU/L23eYch6lXFHz7r3NFavIcwDNa/AAqywfxyxh13OeRy+P0cg7NDpWEETWspXeI4Ek8otw==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
+      "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
       "cpu": [
         "arm64"
       ],
@@ -5102,10 +5153,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
+      "integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
+      "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.29.tgz",
-      "integrity": "sha512-i62vBVoPaVe9A3mc6gJG07n0/e7FVeAvdD9uzZTtGLiuIfVfIBta8EMquzvf+POLycSk79Z6lRhGPZPJPYiQaA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
+      "integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
       "cpu": [
         "x64"
       ],
@@ -5119,9 +5202,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.29.tgz",
-      "integrity": "sha512-YER0XU1xqFdK0hKkfSVX1YIyCvMDI7K07GIpefPvcfyNGs38AXKhb2byySDjbVxkdl4dycaxxhRyhQ2gKSlsFQ==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
+      "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
       "cpu": [
         "x64"
       ],
@@ -5135,9 +5218,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.29.tgz",
-      "integrity": "sha512-po+WHw+k9g6FAg5IJ+sMwtA/fIUL3zPQ4m/uJgONBATCVnDDkyW6dBA49uHNVtSEvjvhuD8DVWdFP847YTcITw==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
+      "integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
       "cpu": [
         "arm64"
       ],
@@ -5151,9 +5234,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.29.tgz",
-      "integrity": "sha512-h+NjOrbqdRBYr5ItmStmQt6x3tnhqgwbj9YxdGPepbTDamFv7vFnhZR0YfB3jz3UKJ8H3uGJ65Zw1VsC+xpFkg==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
+      "integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
       "cpu": [
         "ia32"
       ],
@@ -5167,9 +5250,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.11.29",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.29.tgz",
-      "integrity": "sha512-Q8cs2BDV9wqDvqobkXOYdC+pLUSEpX/KvI0Dgfun1F+LzuLotRFuDhrvkU9ETJA6OnD2+Fn/ieHgloiKA/Mn/g==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
+      "integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
       "cpu": [
         "x64"
       ],
@@ -5189,18 +5272,18 @@
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5213,9 +5296,9 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
     "node_modules/@types/google-protobuf": {
@@ -8483,9 +8566,9 @@
       }
     },
     "node_modules/llamaindex/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8933,42 +9016,55 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/msgpackr": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
-      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
-      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "node-gyp-build-optional-packages": "5.0.7"
+        "node-gyp-build-optional-packages": "5.2.2"
       },
       "bin": {
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/msgpackr-extract/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
-      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "dev": true,
       "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
@@ -9032,13 +9128,10 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "dev": true,
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
-      }
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -9093,9 +9186,9 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -9270,9 +9363,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
-      "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
+      "integrity": "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -9307,23 +9400,23 @@
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
     },
     "node_modules/parcel": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.15.2.tgz",
-      "integrity": "sha512-+ZFhK66uYSwEju8gd3d1qDrBO9JzUNjySnjVJHm9M2boHVDOJl0ZcMQNHTQD9Oyhcba6sf3yIQecjNK1+UvpWg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.16.4.tgz",
+      "integrity": "sha512-RQlrqs4ujYNJpTQi+dITqPKNhRWEqpjPd1YBcGp50Wy3FcJHpwu0/iRm7XWz2dKU/Bwp2qCcVYPIeEDYi2uOUw==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.15.2",
-        "@parcel/core": "2.15.2",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/events": "2.15.2",
-        "@parcel/feature-flags": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/package-manager": "2.15.2",
-        "@parcel/reporter-cli": "2.15.2",
-        "@parcel/reporter-dev-server": "2.15.2",
-        "@parcel/reporter-tracer": "2.15.2",
-        "@parcel/utils": "2.15.2",
+        "@parcel/config-default": "2.16.4",
+        "@parcel/core": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/package-manager": "2.16.4",
+        "@parcel/reporter-cli": "2.16.4",
+        "@parcel/reporter-dev-server": "2.16.4",
+        "@parcel/reporter-tracer": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -9337,79 +9430,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/parcel/node_modules/@parcel/fs": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.2.tgz",
-      "integrity": "sha512-/Xe+eFbxH43vBCZD+L0nkyIKo8i/nYQpRqzum4YTEoG8WHdcwNl12L9dOcM6EwpaCf6amNVjzBQJMwQ+6E1Y4A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/feature-flags": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/types-internal": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.15.2"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
-      }
-    },
-    "node_modules/parcel/node_modules/@parcel/node-resolver-core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.2.tgz",
-      "integrity": "sha512-MOWpFAuKnVMSZSoXZ9OG1Z7BNSW9IVnDA3DM3c8UYrSR8My7Wng0aen0MyjC3s98N1FEwCodESGfu0+7PpZOIA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/rust": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/parcel/node_modules/@parcel/package-manager": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.15.2.tgz",
-      "integrity": "sha512-0n8QupNyXp9CJZV6LohBpAqopLecQrave4kHG/T9CeCeqlJcQnYs+N+zio4mPlv7jXpnJHy+CF96Ce2wy/n1+Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.15.2",
-        "@parcel/fs": "2.15.2",
-        "@parcel/logger": "2.15.2",
-        "@parcel/node-resolver-core": "3.6.2",
-        "@parcel/types": "2.15.2",
-        "@parcel/utils": "2.15.2",
-        "@parcel/workers": "2.15.2",
-        "@swc/core": "^1.11.24",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.15.2"
       }
     },
     "node_modules/parcel/node_modules/chalk": {
@@ -10195,12 +10215,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
-      "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10210,26 +10230,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.0",
-        "@rollup/rollup-android-arm64": "4.40.0",
-        "@rollup/rollup-darwin-arm64": "4.40.0",
-        "@rollup/rollup-darwin-x64": "4.40.0",
-        "@rollup/rollup-freebsd-arm64": "4.40.0",
-        "@rollup/rollup-freebsd-x64": "4.40.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.0",
-        "@rollup/rollup-linux-arm64-musl": "4.40.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-musl": "4.40.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.0",
-        "@rollup/rollup-win32-x64-msvc": "4.40.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/Clarifai/clarifai-nodejs#readme",
   "devDependencies": {
-    "@parcel/packager-ts": "^2.15.2",
-    "@parcel/transformer-typescript-types": "^2.15.2",
+    "@parcel/packager-ts": "^2.16.4",
+    "@parcel/transformer-typescript-types": "^2.16.4",
     "@types/async": "^3.2.24",
     "@types/google-protobuf": "^3.15.12",
     "@types/js-yaml": "^4.0.9",
@@ -57,7 +57,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "parcel": "^2.15.2",
+    "parcel": "^2.16.4",
     "prettier": "3.2.4",
     "typedoc": "^0.25.12",
     "typedoc-plugin-include-example": "^1.2.0",
@@ -108,6 +108,9 @@
     "tar-fs@3": "^3.1.1",
     "glob@10": "^10.5.0",
     "mammoth": "^1.11.0",
-    "@smithy/config-resolver": "^4.4.0"
+    "@smithy/config-resolver": "^4.4.0",
+    "rollup@4": "^4.59.0",
+    "@parcel/reporter-dev-server": "^2.16.4",
+    "ajv@8": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add npm overrides for `rollup@4`, `ajv@8`, and `@parcel/reporter-dev-server` to resolve Dependabot alerts `#50`, `#67`, `#70`
- Bump `parcel`, `@parcel/packager-ts`, and `@parcel/transformer-typescript-types` devDeps from `^2.15.2` to `^2.16.4` to keep the parcel plugin ecosystem aligned
- `ajv@6` copies remain unfixed — no v6 patch exists, blocked on upstream consumers migrating to ajv v8
