### PR TITLE
fix: upgrade protobuf dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9959,9 +9959,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "fast-xml-parser": "^4.5.5",
     "handlebars": "^4.7.9",
     "@xmldom/xmldom": "^0.8.13",
+    "protobufjs@6": "^6.11.5",
     "protobufjs@7": "^7.5.5",
     "vite": "^6.4.2",
     "lodash-es": "^4.18.0",


### PR DESCRIPTION
## Overview
Resolves: https://github.com/Clarifai/clarifai-nodejs/security/dependabot/120

1. There IS a 6.x backport patch. 6.11.5 was published 2026-04-14 (one day before the v7 fix 7.5.5), and 6.11.6 on 2026-05-03. These are security backports. Dependabot just doesn't know about them — its advisory only lists 7.5.5 as the fix. We can override protobufjs@6 to ^6.11.5 right now.

2. This project is not actually exploitable. The CVE (CVE-2026-41242) requires the attacker to control the protobuf schema or JSON descriptor being loaded. Looking at clarifai-nodejs-grpc, it calls protoLoader.loadSync with hardcoded .proto files from its own bundled proto/ directory — no user-supplied schemas ever reach protobufjs. The onnx-proto path is the same story (static bundled .proto files). So even without patching, the preconditions for exploitation aren't met here.